### PR TITLE
Fix .env.example comments

### DIFF
--- a/sample-app/.env.example
+++ b/sample-app/.env.example
@@ -1,6 +1,8 @@
 DB_FILE_NAME = './database.txt'
 API_BASE = 'https://api.miro.com/v1'
-BASE_URL = 'https://-------.ngrok.io'   # Must be replaced after each restart ngrok
-CLIENT_ID = '1004457346318492837'       # Must be replaced from "manage apps" settings
-CLIENT_SECRET = '5KSBs8DHnqKMq87iuybci' # Must be replaced from "manage apps" settings
-WEBHOOKS_VERIFICATION_TOKEN = ''        # Must be replaced from "manage apps" settings. Coming soon
+# Must be replaced after each restart ngrok
+BASE_URL = 'https://-------.ngrok.io'
+# Must be replaced from "manage apps" settings
+CLIENT_ID = ''
+# Must be replaced from "manage apps" settings
+CLIENT_SECRET = ''


### PR DESCRIPTION
Comments should be on separate lines to not be parsed as part of the secret

```.env
FOO='some secret' # Comment 
```

will result in `FOO` containing the comment

```.env
# Comment
FOO='some secret'
```

Will work correctly.

Closes #18 