### PR TITLE
[prototype apps] Update instructions & rename APP_ID to CLIENT_ID

### DIFF
--- a/prototyping/README.md
+++ b/prototyping/README.md
@@ -12,8 +12,8 @@ _This plugin was created for demo purpose, it does not ready for production usag
 # How to build
 
 - Run `npm install`
+- Replace `CLIENT_ID` in [`src/config.ts`](src/config.ts) file You can get _CLIENT_ID_ in app settings.
 - Run `npm run build` or `npm run watch` to compile app
 - Run serve the app `npx serve -p 8081`
 - Run `ngrok` using `npx ngrok http 8081`
-- Replace APP*ID in config file to your \_App ID*. You can get _App Id_ in app settings.
 - Get https url from _ngrok_ and paste it in `iframe url` in your app settings.

--- a/prototyping/package.json
+++ b/prototyping/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "prebuild": "rm -rf dist",
     "build": "NODE_ENV=production webpack",
-    "watch": "webpack -w"
+    "watch": "NODE_ENV=development webpack -w"
   },
   "license": "MIT",
   "devDependencies": {

--- a/prototyping/src/bottom-panel-controller.ts
+++ b/prototyping/src/bottom-panel-controller.ts
@@ -1,7 +1,7 @@
-import {APP_ID} from 'config'
+import {CLIENT_ID} from 'config'
 
 export function findStartHotspot(shapes: SDK.IWidget[]): SDK.IWidget | undefined {
-  return shapes.find((shape) => shape.metadata[APP_ID] && shape.metadata[APP_ID].startHotspot)
+  return shapes.find((shape) => shape.metadata[CLIENT_ID] && shape.metadata[CLIENT_ID].startHotspot)
 }
 
 export async function enterPrototypingMode(startHotspotWidget: SDK.IWidget): Promise<SDK.IWidget | void> {
@@ -101,7 +101,7 @@ async function zoomToWidget(w: SDK.IWidget) {
 }
 
 export function isHotspotWidget(widget: SDK.IWidget): Promise<boolean> {
-  return widget.metadata[APP_ID] && widget.metadata[APP_ID].hotspot
+  return widget.metadata[CLIENT_ID] && widget.metadata[CLIENT_ID].hotspot
 }
 
 async function showHotspots() {
@@ -195,7 +195,7 @@ export async function createStartHotspot() {
             borderWidth: 0,
           },
           metadata: {
-            [APP_ID]: {
+            [CLIENT_ID]: {
               hotspot: true,
               startHotspot: true,
             },
@@ -236,7 +236,7 @@ export async function createHotspot(pos?: {x: number; y: number}): Promise<void>
 
   await miro.board.widgets.create({
     metadata: {
-      [APP_ID]: {
+      [CLIENT_ID]: {
         hotspot: true,
       },
     },

--- a/prototyping/src/config.ts
+++ b/prototyping/src/config.ts
@@ -1,3 +1,3 @@
-export const APP_ID = '' // Add your APP ID
+export const CLIENT_ID = '' // Add your CLIENT_ID
 export const EDIT_WIDTH = 280
 export const PLAY_WIDTH = 320

--- a/prototyping2/README.md
+++ b/prototyping2/README.md
@@ -12,8 +12,8 @@ _This plugin was created for demo purpose, it does not ready for production usag
 # How to build
 
 - Run `npm install`
+- Replace `CLIENT_ID` in [`src/config.ts`](src/config.ts) file You can get _CLIENT_ID_ in app settings.
 - Run `npm run build` or `npm run watch` to compile app
 - Run serve the app `npx serve -p 8081`
 - Run `ngrok` using `npx ngrok http 8081`
-- Replace APP*ID in config file to your \_App ID*. You can get _App Id_ in app settings.
 - Get https url from _ngrok_ and paste it in `iframe url` in your app settings.

--- a/prototyping2/package.json
+++ b/prototyping2/package.json
@@ -3,8 +3,9 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
+    "prebuild": "rm -rf dist",
     "build": "NODE_ENV=production webpack",
-    "watch": "webpack -w"
+    "watch": "NODE_ENV=development webpack -w"
   },
   "license": "MIT",
   "devDependencies": {

--- a/prototyping2/src/bottom-panel-controller.ts
+++ b/prototyping2/src/bottom-panel-controller.ts
@@ -1,7 +1,7 @@
-import {APP_ID} from 'config'
+import {CLIENT_ID} from 'config'
 
 export function findStartHotspot(shapes: SDK.IWidget[]): SDK.IWidget | undefined {
-  return shapes.find((shape) => shape.metadata[APP_ID] && shape.metadata[APP_ID].startHotspot)
+  return shapes.find((shape) => shape.metadata[CLIENT_ID] && shape.metadata[CLIENT_ID].startHotspot)
 }
 
 export async function enterPrototypingMode(startHotspotWidget: SDK.IWidget): Promise<SDK.IWidget | void> {
@@ -110,7 +110,7 @@ async function zoomToWidget(w: SDK.IWidget) {
 }
 
 export function isHotspotWidget(widget: SDK.IWidget) {
-  return widget.metadata[APP_ID] && widget.metadata[APP_ID].hotspot
+  return widget.metadata[CLIENT_ID] && widget.metadata[CLIENT_ID].hotspot
 }
 
 async function showHotspots() {
@@ -204,7 +204,7 @@ export async function createStartHotspot() {
             borderWidth: 0,
           },
           metadata: {
-            [APP_ID]: {
+            [CLIENT_ID]: {
               hotspot: true,
               startHotspot: true,
             },
@@ -244,7 +244,7 @@ export async function createHotspot(pos?: {x: number; y: number}) {
 
   await miro.board.widgets.create({
     metadata: {
-      [APP_ID]: {
+      [CLIENT_ID]: {
         hotspot: true,
       },
     },

--- a/prototyping2/src/config.ts
+++ b/prototyping2/src/config.ts
@@ -1,3 +1,3 @@
-export const APP_ID = '' // Add you APP ID
+export const CLIENT_ID = '' // Add your CLIENT_ID
 export const EDIT_WIDTH = 280
 export const PLAY_WIDTH = 320


### PR DESCRIPTION
- Fix order of instructions in `README`
- Rename `APP_ID` to `CLIENT_ID`
- Make sure watch command runs in `development` mode