### PR TITLE
Add links to dev docs; add note about not using Safari for local dev (no HTTPS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,20 @@
 
 <img alt="Miro" src="https://github.com/miroapp/app-examples/raw/beta/assets/Banner.png" />
 
-Welcome to Miro App Examples! In this repository you can find examples of apps built on top of Miro's Platform 2.0. Make sure you visit our [documentation](https://beta.developers.miro.com) or read our [official blog post](https://miro.com/blog/developer-platform-beta) to learn more.
+Welcome to Miro App Examples! In this repository you can find examples of apps built on top of Miro's Developer Platform 2.0.<br />
+Make sure you visit our [developer documentation](https://beta.developers.miro.com) or read our [official blog post](https://miro.com/blog/developer-platform-beta) to learn more.
 
 ## Web SDK
 
-The fastest way to bootstrap a new app is by using [`create-miro-app`](https://www.npmjs.com/package/create-miro-app)
+The fastest way to bootstrap a new app is by using [`create-miro-app`](https://www.npmjs.com/package/create-miro-app).<br />
+To get started, run the following command:
 
-```
+```shell
 npx create-miro-app@beta
+
+// or
+
+yarn create miro-app@beta
 ```
 
 |                                                         | Description                                                                                                                                        |
@@ -28,10 +34,10 @@ npx create-miro-app@beta
 
 ## REST API
 
-|                                       | Description                                                                              |
-| ------------------------------------- | ---------------------------------------------------------------------------------------- |
-| [python_oauth](examples/oauth/python) | This python sample demonstrates how to implement the Oauth 2.0 authorization code flow in Miro. |
-| [node_oauth](examples/oauth/node) | This NodeJS sample demonstrates how to implement the Oauth 2.0 authorization code flow in Miro and make an API request to a Miro endpoint. |
+|                                       | Description                                                                                                                                |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| [python_oauth](examples/oauth/python) | This python sample demonstrates how to implement the Oauth 2.0 authorization code flow in Miro.                                            |
+| [node_oauth](examples/oauth/node)     | This NodeJS sample demonstrates how to implement the Oauth 2.0 authorization code flow in Miro and make an API request to a Miro endpoint. |
 
 <p>&nbsp;</p>
 

--- a/examples/blob-maker/README.md
+++ b/examples/blob-maker/README.md
@@ -1,6 +1,14 @@
-# Blob Maker App
+# Blob maker app
 
-## How to start locally (Drag and drop functionality will not work locally see below):
+**&nbsp;ℹ&nbsp;Note**:
+
+- Drag and drop functionality doesn't work if you serve the app on localhost. \
+  To make drag and drop available, deploy the app to a publicly accessible location.
+- We recommend a Chromium-based web browser for local development with HTTP. \
+  Safari enforces HTTPS; therefore, it doesn't allow localhost through HTTP.
+- For more information about implementing [drag and drop](https://beta.developers.miro.com/docs/add-drag-and-drop-to-your-app), visit our [developer documentation](https://beta.developers.miro.com).
+
+## How to start locally
 
 - Run `yarn` or `npm install` to install dependencies
 - Run `yarn start` or `npm start` to start developing, you should have a URL
@@ -14,11 +22,7 @@ http://localhost:3000
 - open a board & you should see your app in the main toolbar when you click the
   three dots.
 
-**CAVEAT: the drag and drop functionality will not work when the app is served on localhost.**
-
-**If you would like to use app to its full functionality you will need to deploy the app to a publicly accessible location.**
-
-## How to start with Glitch:
+## How to start with Glitch
 
 [Glitch Documentation](https://help.glitch.com/kb/article/20-importing-code-from-github/)
 
@@ -29,10 +33,10 @@ http://localhost:3000
 - After the app starts up, it will have a unique url that will serve the app over https. Click "Preview" in the bottom bar and then "Preview in a new window".
 - You should see "Great, your app is running locally", copy the url.
 - Paste the URL in `App URL` in your app settings
-- Open a board & you should see your app in the main toolbar when you click the
+- Open a board; you should see your app in the main toolbar when you click the
   three dots.
 
-## How to build the app:
+## How to build the app
 
 Run `yarn run build` or `npm run build` and this will generate a static output
 inside `dist/` which you can host on static hosting service.
@@ -52,4 +56,4 @@ inside `dist/` which you can host on static hosting service.
 
 ### About the app
 
-This sample app shows how you can create dynamic blob svgs on the fly and drag and drop them into a Miro board.
+This sample app shows how you can create dynamic blob SVGs on the fly, and drag and drop them onto a Miro board.

--- a/examples/calendar/README.md
+++ b/examples/calendar/README.md
@@ -1,6 +1,12 @@
-# Miro Calendar sample app
+# Miro calendar sample app
 
-## How to start:
+**&nbsp;ℹ&nbsp;Note**:
+
+- We recommend a Chromium-based web browser for local development with HTTP. \
+  Safari enforces HTTPS; therefore, it doesn't allow localhost through HTTP.
+- For more information about [building a calendar](https://beta.developers.miro.com/docs/building-a-calendar-app-in-miro), visit our [developer documentation](https://beta.developers.miro.com).
+
+## How to start
 
 - Run `yarn` or `npm install` to install dependencies.
 - Run `yarn start` or `npm start` to start developing. \
@@ -14,7 +20,7 @@ http://localhost:3000
 - Open a board and click the three dots (...) or the chevron (>>) on the left
   toolbar. You should see the Miro calendar app.
 
-## How to build the app:
+## How to build the app
 
 - Run `yarn run build` or `npm run build`. \
   This generates a static output inside `dist/`, which you can host on a static hosting service.

--- a/examples/drag-and-drop/README.md
+++ b/examples/drag-and-drop/README.md
@@ -1,6 +1,12 @@
-# Miro Drag and Drop App
+# Miro drag and drop app
 
-## How to start:
+**&nbsp;ℹ&nbsp;Note**:
+
+- We recommend a Chromium-based web browser for local development with HTTP. \
+  Safari enforces HTTPS; therefore, it doesn't allow localhost through HTTP.
+- For more information about implementing [drag and drop](https://beta.developers.miro.com/docs/add-drag-and-drop-to-your-app), visit our [developer documentation](https://beta.developers.miro.com).
+
+## How to start
 
 - Run `yarn` or `npm install` to install dependencies.
 - Run `yarn start` or `npm start` to start developing. \
@@ -14,7 +20,7 @@ http://localhost:3000
 - Open a board and click the three dots (...) or the chevron (>>) on the left
   toolbar. You should see the Miro calendar app.
 
-## How to build the app:
+## How to build the app
 
 - Run `yarn run build` or `npm run build`. \
   This generates a static output inside `dist/`, which you can host on a static hosting service.

--- a/examples/oauth/node/README.md
+++ b/examples/oauth/node/README.md
@@ -1,10 +1,11 @@
-# Miro OAuth2.0 
+# Miro OAuth2.0
 
-## Prerequisites:
+## Prerequisites
+
 - Create an app in Miro (https://miro.com/app/settings/user-profile/apps)
 - Install Localtunnel (or similar, such as Ngrok)
 
-## How to start:
+## How to start
 
 - Clone or download repo
 - cd to root folder
@@ -18,7 +19,7 @@ redirectURL={YOUR_REDIRECT_URL}
 boardId={MIRO_BOARD_ID}
 ```
 
-In this example, we will host our local environment over `HTTPS` using [Localtunnel](https://www.npmjs.com/package/localtunnel). 
+In this example, we will host our local environment over `HTTPS` using [Localtunnel](https://www.npmjs.com/package/localtunnel).
 (You can use other services such as [ngrok](https://ngrok.com/download) as well.)
 
 - Install [localtunnel](https://www.npmjs.com/package/localtunnel) (or your preferred service)
@@ -29,13 +30,12 @@ In this example, we will host our local environment over `HTTPS` using [Localtun
 - From your Miro app settings, grab the Client ID and Client Secret. Paste this into your `.env` `clientId` and `clientSecret` variables (above)
 
 ## How to run the project
+
 - Run `npm run start` to run the project
 - Your express server console should reflect "Listening on Localhost 3000" (or the port of your choice)
 - Once your server is running, copy the `Installation URL` for your app, under "Share App" in the Miro App UI
 - Navigate to the authorization screen via the Installation URL and authorize/install the app
-- This should redirect you to your Localtunnel URL, where you will see the JSON API response from the [GET Board API](https://beta.developers.miro.com/reference/get-a-board) displayed in the browser 
-  
-
+- This should redirect you to your Localtunnel URL, where you will see the JSON API response from the [GET Board API](https://beta.developers.miro.com/reference/get-a-board) displayed in the browser
 
 ## Folder structure
 
@@ -49,7 +49,7 @@ In this example, we will host our local environment over `HTTPS` using [Localtun
 
 ### About the app
 
-This sample app is intended to demonstrate the OAuth 2.0 flow that is required to call Miro's V2 APIs. 
+This sample app is intended to demonstrate the OAuth 2.0 flow that is required to call Miro's V2 APIs.
 Devs may consider using this Node.js demo as a structural basis for any other preferred language/framework.
 NOTE: Any comments with "--->" signify part of a significant step in the flow. Comments without "--->" are added for additional reference on code.
 

--- a/examples/stickynotes-to-shapes/README.md
+++ b/examples/stickynotes-to-shapes/README.md
@@ -1,6 +1,12 @@
-# Stickies to shapes sample app
+# Sticky notes to shapes sample app
 
-## How to start:
+**&nbsp;ℹ&nbsp;Note**:
+
+- We recommend a Chromium-based web browser for local development with HTTP. \
+  Safari enforces HTTPS; therefore, it doesn't allow localhost through HTTP.
+- For more information about [converting sticky notes to shapes](https://beta.developers.miro.com/docs/converting-sticky-notes-to-shapes), visit our [developer documentation](https://beta.developers.miro.com).
+
+## How to start
 
 - Run `yarn` or `npm install` to install dependencies.
 - Run `yarn start` or `npm start` to start developing. \
@@ -14,7 +20,7 @@ http://localhost:3000
 - Open a board and click the three dots (...) or the chevron (>>) on the left
   toolbar. You should see the Miro starter app.
 
-## How to build the app:
+## How to build the app
 
 - Run `yarn run build` or `npm run build`. \
   This generates a static output inside `dist/`, which you can host on a static hosting service.

--- a/examples/template-builder/README.md
+++ b/examples/template-builder/README.md
@@ -1,5 +1,11 @@
 # Template builder sample app
 
+**&nbsp;ℹ&nbsp;Note**:
+
+- We recommend a Chromium-based web browser for local development with HTTP. \
+  Safari enforces HTTPS; therefore, it doesn't allow localhost through HTTP.
+- For more information, visit our [developer documentation](https://beta.developers.miro.com).
+
 ## How to start
 
 - Run `yarn` or `npm install` to install the app dependencies.

--- a/examples/wordle/README.md
+++ b/examples/wordle/README.md
@@ -1,6 +1,12 @@
 # Miro Wordle sample app
 
-## How to start:
+**&nbsp;ℹ&nbsp;Note**:
+
+- We recommend a Chromium-based web browser for local development with HTTP. \
+  Safari enforces HTTPS; therefore, it doesn't allow localhost through HTTP.
+- For more information, visit our [developer documentation](https://beta.developers.miro.com).
+
+## How to start
 
 - Run `yarn` or `npm install` to install dependencies.
 - Run `yarn start` or `npm start` to start developing. \
@@ -14,7 +20,7 @@ http://localhost:3000
 - Open a board and click the three dots (...) or the chevron (>>) on the left
   toolbar. You should see the Miro Wordle app.
 
-## How to build the app:
+## How to build the app
 
 - Run `yarn run build` or `npm run build`. \
   This generates a static output inside `dist/`, which you can host on a static hosting service.

--- a/examples/youtube-room/README.md
+++ b/examples/youtube-room/README.md
@@ -1,38 +1,49 @@
-# YouTube Room
+# YouTube room
 
-This Miro Web SDK app shows you how you can sync multiple YouTube players across different user sessions. This example utilises an [Express server](https://expressjs.com/) and [Socket.IO](https://socket.io/)—a library for implemeting a [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API) in web applications. This might be useful for teachers, workshop presenters, and others looking to broadcast a video to multiple users on the same board.
+**&nbsp;ℹ&nbsp;Note**:
+
+- We recommend a Chromium-based web browser for local development with HTTP. \
+  Safari enforces HTTPS; therefore, it doesn't allow localhost through HTTP.
+- Developing the app involves creating 2 separate apps, and testing them with different user sessions. \
+  We recommend opening 2 browser sessions with different users to test the full functionality of the app.
+- For more information, visit our [developer documentation](https://beta.developers.miro.com).
+
+This Miro Web SDK app shows you how you can sync multiple YouTube players across different user sessions \
+The example uses an [Express server](https://expressjs.com/) and [Socket.IO](https://socket.io/), a library to implement a [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API) in web applications. \
+The app can be useful for teachers, workshop presenters, and others looking to broadcast a video to multiple users on the same board.
 
 ## How it works
 
-This example contains 2 separate apps that are connected by a WebSocket. There is a facilitator app, and a participant app. Each one serves differnet purposes for the funcationality of the YouTube room.
+This example contains 2 separate apps that are connected by a WebSocket:
+
+- A facilitator app, and
+- A participant app.
+
+Each app serves different purposes that enable the functionality of the YouTube room.
 
 ### Facilitator
 
-This app is meant to only be installed by 1 user, the facilitator of the Miro board. It contains the funcationality to start, update, or chagne a YouTube video, that will in turn be broadcasted and synced across all of the participants.
+This app is meant to be installed by only one user: the facilitator of the Miro board. \
+It contains the functionality to start, update, and change a YouTube video. The video is in turn broadcasted and synced across all participants.
 
 ### Participant
 
-This app can be installed by multiple users. It contains the functiaonlity that keeps the YouTube player in sync with the facilitator.
+This app can be installed by multiple users. It contains the functionality that keeps the YouTube player in sync with the facilitator app.
 
-## Getting Started
+## Getting started
 
-> Developing this app requires you to create 2 separate apps, and test them across different user sessions.
->
-> We reccomend opening two browser sessions with different users to test the full functionailty of this app.
-
-- Run `yarn` or `npm install` to install dependencies
+- Run `yarn` or `npm install` to install dependencies.
 - Run `yarn start` or `npm start` to start developing. Your app should be available on a url that looks something like this:
 
 ```
 http://localhost:3000
 ```
 
-- [Create a new Miro app](https://developers.miro.com/docs/create-your-app-in-miro) for the Facilitator part of the app.
+- [Create a new Miro app](https://developers.miro.com/docs/create-your-app-in-miro) for the facilitator app component.
 - Paste `http://localhost:3000/facilitator` in the `App URL` box in your Facilitator app settings.
-- [Create a new Miro app](https://developers.miro.com/docs/create-your-app-in-miro) for the Participant part of the app.
-- Paste `http://localhost:3000/participant` in the `App URL` box in your Participant app settings.
-- Open a board and click the three dots (...) or the chevron (>>) on the left
-  toolbar. You should see the Miro calendar app.
+- [Create a new Miro app](https://developers.miro.com/docs/create-your-app-in-miro) for the participant app component.
+- Paste `http://localhost:3000/participant` in the `App URL` box in your participant app settings.
+- Open a board and click the three dots (...) or the chevron (>>) on the left toolbar. You should see the Miro calendar app.
 
 ### Project Structure
 
@@ -43,38 +54,38 @@ Below is a directory of important files needed for this example.
 ├── src
 │  └── assets
 │      └── style.css <-- CSS styles for the app.
-│  └── facilitator-modal.js <-- Connects to the WebSocket, and syncronizes other Participant apps.
-│      facilitator.js <-- Initializes the Facilitator app in Miro
-│      participant-modal.js <-- Connects to the WebSocket, and syncronizes the YouTube player to the Facilitator.
-│      participant.js <-- Initializs the Participant app in Miro
-├── facilitator-modal.html <-- The HTML for the Facilitator modal
-├── facilitator.html <-- The HTML for the Facilitator app
-├── participant-modal.html <-- The HTML for the Participant modal
-├── participant.html <-- The HTML for the Participant app
-└── server.js <-- The main server. This serves the HTML for both apps. It also initites the WebSocket.
+│  └── facilitator-modal.js <-- Connects to the WebSocket, and syncronizes other participant apps.
+│      facilitator.js <-- Initializes the facilitator app in Miro
+│      participant-modal.js <-- Connects to the WebSocket, and syncronizes the YouTube player with the facilitator app.
+│      participant.js <-- Initializes the participant app in Miro
+├── facilitator-modal.html <-- The HTML for the facilitator app modal
+├── facilitator.html <-- The HTML for the facilitator app
+├── participant-modal.html <-- The HTML for the participant app modal
+├── participant.html <-- The HTML for the participant app
+└── server.js <-- The main server. This serves the HTML for both apps. It also initiates the WebSocket.
 ```
 
 ## Using the app
 
-Using both the Facilitator and Participant app is straightforward. Continue reading below to read a short description on how each of them work. If you'd like to see a video on how they work, you can find one [here](http://www.youtube.com/watch?v=_HTZFf8bkNI)!
+Using both the facilitator and participant app is straightforward. Continue reading below to read a short description on how each of them work. \
+[Watch a video to see how they work](http://www.youtube.com/watch?v=_HTZFf8bkNI).
 
 ### Facilitator
 
-By opening the Facilitator app, you'll be greeted with a modal that allows you to paste a YouTube URL in. After selecting the desired video, you're able to click the "Open Video for Participants" button, and in turn a modal will open on all of the participants boards that have the Participant app installed.
+By opening the facilitator app, you'll be greeted with a modal that allows you to paste a YouTube URL in. After selecting the desired video, you're able to click the "Open Video for Participants" button, and in turn a modal will open on all of the participants boards that have the participant app installed.
 
-As a Faciliatator, you're also able to pause the video, scub to a new point, or even change the video entirely. All of these actions will be reflected in the participant's modal.
+As a facilitator, you can play, pause, and stop the video, go to a new point, as well as completely replace the video with a different one. \
+Each of these actions is reflected in the participant app's modal.
 
 ### Participant
 
-After installing the Participant app, no further setup in required. It will work out of the box, and a modal will appear with a YouTube video whenever the Facilitator of the room starts presenting.
+After installing the participant app, no further setup in required. It will work out of the box, and a modal will appear with a YouTube video whenever the facilitator of the room starts presenting.
 
 ## Deploying your app
 
 When you're done developing your app, you will need to build and deploy your app before you can use it in production.
 
-- Run `yarn run build` or `npm run build` to genrate a static build of your project in `dist`.
-- Host built project on a service like [Heroku](https://www.heroku.com/), or [Glitch](https://glitch.com/).
-
-> Don't forget that if you're using this app, that there are 2 separate endpoints you will need to use, meaning you will need to create 2 separate apps (Facilitator and Participant).
+- Run `yarn run build` or `npm run build` to generate a static build of your project in `dist`.
+- Host the built project on a service like [Heroku](https://www.heroku.com/), or [Glitch](https://glitch.com/).
 
 If you get stuck or have questions, feel free to [join our Discord](https://bit.ly/miro-developers).


### PR DESCRIPTION
- Add relevant links to developer documentation sections to Readme files of app examples.
- Add note about Safari not supporting HTTP for local development, so `http://localhost:3000` won't work on Safari.