### PR TITLE
DX-1085 Web SDK Remove all references to yarn. Add info about using npm and npx in all examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,15 @@
 <img alt="Miro Developer Platform" src="https://github.com/miroapp/app-examples/raw/main/assets/Banner.png" />
 
 Welcome to Miro App Examples! In this repository you can find examples of apps built on top of the Miro Developer Platform 2.0.<br />
-Make sure you visit our [developer documentation](https://beta.developers.miro.com) to learn more.
+Make sure you visit our [developer documentation](https://developers.miro.com) to learn more.
+
+**&nbsp;ℹ&nbsp;Note**:
+
+- We recommend a Chromium-based web browser for local development with HTTP. \
+  Safari enforces HTTPS; therefore, it doesn't allow localhost through HTTP.
+- All examples use `npm` as a package manager and `npx` as a package runner. \
+  If you prefer, you can install and use equivalent alternatives, such as `yarn` or `pnpm`.
+- For more information, visit our [developer documentation](https://developers.miro.com).
 
 ### Miro Web SDK
 
@@ -13,11 +21,7 @@ The fastest way to bootstrap a new app is by using [`create-miro-app`](https://w
 To get started, run the following command:
 
 ```shell
-npx create-miro-app@latest
-
-// or
-
-yarn create miro-app@latest
+npx create-miro-app
 ```
 
 |                                                         | Description                                                                                                                                        |

--- a/examples/blob-maker/README.md
+++ b/examples/blob-maker/README.md
@@ -6,12 +6,14 @@
   In this example, drag and drop functionality doesn't work if you serve the app on localhost.
 - We recommend a Chromium-based web browser for local development with HTTP. \
   Safari enforces HTTPS; therefore, it doesn't allow localhost through HTTP.
+- All examples use `npm` as a package manager and `npx` as a package runner. \
+  If you prefer, you can install and use equivalent alternatives, such as `yarn` or `pnpm`.
 - For more information about implementing [drag and drop](https://developers.miro.com/docs/add-drag-and-drop-to-your-app), visit our [developer documentation](https://developers.miro.com).
 
 ### How to start locally
 
-- Run `yarn` or `npm install` to install dependencies.
-- Run `yarn start` or `npm start` to start developing. \
+- Run `npm install` to install dependencies.
+- Run `npm start` to start developing. \
   Your URL should be similar to this example: \
   ```
   http://localhost:3000
@@ -35,7 +37,7 @@
 
 ### How to build the app
 
-- Run `yarn run build` or `npm run build`. \
+- Run `npm run build`. \
   This generates a static output inside `dist/`, which you can host on a static hosting service.
 
 ### Folder structure

--- a/examples/calendar/README.md
+++ b/examples/calendar/README.md
@@ -4,12 +4,14 @@
 
 - We recommend a Chromium-based web browser for local development with HTTP. \
   Safari enforces HTTPS; therefore, it doesn't allow localhost through HTTP.
+- All examples use `npm` as a package manager and `npx` as a package runner. \
+  If you prefer, you can install and use equivalent alternatives, such as `yarn` or `pnpm`.
 - For more information about [building a calendar](https://developers.miro.com/docs/building-a-calendar-app-in-miro), visit our [developer documentation](https://developers.miro.com).
 
 ### How to start locally
 
-- Run `yarn` or `npm install` to install dependencies.
-- Run `yarn start` or `npm start` to start developing. \
+- Run `npm install` to install dependencies.
+- Run `npm start` to start developing. \
   Your URL should be similar to this example: \
   ```
   http://localhost:3000
@@ -19,7 +21,7 @@
 
 ### How to build the app
 
-- Run `yarn run build` or `npm run build`. \
+- Run `npm run build`. \
   This generates a static output inside `dist/`, which you can host on a static hosting service.
 
 ### Folder structure

--- a/examples/connect-firebase/README.md
+++ b/examples/connect-firebase/README.md
@@ -3,9 +3,17 @@
 This project follows our guide _How to connect the Web SDK to a backend_, and it contains the finished code.\
 Read through the guide for an in-depth walkthrough on setting this project up from scratch.
 
+**&nbsp;ℹ&nbsp;Note**:
+
+- We recommend a Chromium-based web browser for local development with HTTP. \
+  Safari enforces HTTPS; therefore, it doesn't allow localhost through HTTP.
+- All examples use `npm` as a package manager and `npx` as a package runner. \
+  If you prefer, you can install and use equivalent alternatives, such as `yarn` or `pnpm`.
+- For more information, visit our [developer documentation](https://developers.miro.com).
+
 ### How to connect to the Firebase backend
 
-- Run `yarn` or `npm install` to install dependencies.
+- Run `npm install` to install dependencies.
 - Open `src/app.js`, and replace the `firebaseConfig` object with the settings from your Firebase project.
 
 ```js
@@ -22,7 +30,7 @@ const firebaseConfig = {
 
 ### How to start locally
 
-- Run `yarn start` or `npm start` to start developing. \
+- Run `npm start` to start developing. \
   Your URL should be similar to this example: \
   ```
   http://localhost:3000
@@ -32,7 +40,7 @@ const firebaseConfig = {
 
 ### How to build the app
 
-- Run `yarn run build` or `npm run build`. \
+- Run `npm run build`. \
   This generates a static output inside `dist/`, which you can host on a static hosting service.
 
 ### About the app

--- a/examples/connect-firebase/index.html
+++ b/examples/connect-firebase/index.html
@@ -21,7 +21,7 @@
       <div class="cs1 ce12">
         <a
           class="button button-primary"
-          href="https://beta.developers.miro.com/docs/create-a-developer-team"
+          href="https://developers.miro.com/docs/build-your-first-hello-world-app#step-2-create-a-developer-team-in-miro"
           target="_blank"
         >
           Create a Developer team

--- a/examples/drag-and-drop/README.md
+++ b/examples/drag-and-drop/README.md
@@ -4,12 +4,14 @@
 
 - We recommend a Chromium-based web browser for local development with HTTP. \
   Safari enforces HTTPS; therefore, it doesn't allow localhost through HTTP.
+- All examples use `npm` as a package manager and `npx` as a package runner. \
+  If you prefer, you can install and use equivalent alternatives, such as `yarn` or `pnpm`.
 - For more information about implementing [drag and drop](https://developers.miro.com/docs/add-drag-and-drop-to-your-app), visit our [developer documentation](https://developers.miro.com).
 
 ### How to start locally
 
-- Run `yarn` or `npm install` to install dependencies.
-- Run `yarn start` or `npm start` to start developing. \
+- Run `npm install` to install dependencies.
+- Run `npm start` to start developing. \
   Your URL should be similar to this example: \
   ```
   http://localhost:3000
@@ -19,7 +21,7 @@
 
 ### How to build the app
 
-- Run `yarn run build` or `npm run build`. \
+- Run `npm run build`. \
   This generates a static output inside `dist/`, which you can host on a static hosting service.
 
 ### Folder structure

--- a/examples/rest/python-flask-starter/README.md
+++ b/examples/rest/python-flask-starter/README.md
@@ -6,7 +6,7 @@ This Python/Flask boilerplate will allow to start using the Miro REST API in a f
 
 - Install the project dependencies: run `pip3 install -r requirements.txt`
 - Copy the environment file to add your credentials: `cp sample.env .env`
-- Edit `.env` to include your Client ID and Client Secret (please follow [this guide](https://beta.developers.miro.com/docs/build-your-first-hello-world-app-1) about how to create a developer app). Note that this demo application works only with [refresh tokens](https://beta.developers.miro.com/reference/oauth-20-authorization-v2).
+- Edit `.env` to include your Client ID and Client Secret (please follow [this guide](https://developers.miro.com/docs/rest-api-build-your-first-hello-world-app) about how to create a developer app). Note that this demo application works only with [refresh tokens](https://developers.miro.com/reference/authorization-flow-for-expiring-tokens).
 - Add `http://127.0.0.1:5000/callback` as a registered redirect URL in your app settings:
   - Go to [App settings](https://miro.com/app/settings/user-profile/apps)
   - Add `http://127.0.0.1:5000/callback` to the `Redirect URI for OAuth2.0:
@@ -30,6 +30,6 @@ This Python/Flask boilerplate will allow to start using the Miro REST API in a f
 
 ### About the app
 
-This sample app shows how you can use the Miro REST API. It implements the full OAuth2 flow and calls the [Create Miro Board API endpoint](https://beta.developers.miro.com/reference/create-a-board)
+This sample app shows how you can use the Miro REST API. It implements the full OAuth2 flow and calls the [Create Miro board API endpoint](https://developers.miro.com/reference/create-board).
 
 This app uses [Flask](https://flask.palletsprojects.com/en/2.1.x/) and [Python](https://www.python.org/).

--- a/examples/stickynotes-to-shapes/README.md
+++ b/examples/stickynotes-to-shapes/README.md
@@ -4,12 +4,14 @@
 
 - We recommend a Chromium-based web browser for local development with HTTP. \
   Safari enforces HTTPS; therefore, it doesn't allow localhost through HTTP.
+- All examples use `npm` as a package manager and `npx` as a package runner. \
+  If you prefer, you can install and use equivalent alternatives, such as `yarn` or `pnpm`.
 - For more information about [converting sticky notes to shapes](https://developers.miro.com/docs/converting-sticky-notes-to-shapes), visit our [developer documentation](https://developers.miro.com).
 
 ### How to start locally
 
-- Run `yarn` or `npm install` to install dependencies.
-- Run `yarn start` or `npm start` to start developing. \
+- Run `npm install` to install dependencies.
+- Run `npm start` to start developing. \
   Your URL should be similar to this example: \
   ```
   http://localhost:3000
@@ -19,7 +21,7 @@
 
 ### How to build the app
 
-- Run `yarn run build` or `npm run build`. \
+- Run `npm run build`. \
   This generates a static output inside `dist/`, which you can host on a static hosting service.
 
 ### Folder structure

--- a/examples/template-builder/README.md
+++ b/examples/template-builder/README.md
@@ -4,12 +4,14 @@
 
 - We recommend a Chromium-based web browser for local development with HTTP. \
   Safari enforces HTTPS; therefore, it doesn't allow localhost through HTTP.
+- All examples use `npm` as a package manager and `npx` as a package runner. \
+  If you prefer, you can install and use equivalent alternatives, such as `yarn` or `pnpm`.
 - For more information, visit our [developer documentation](https://developers.miro.com).
 
 ### How to start locally
 
-- Run `yarn` or `npm install` to install dependencies.
-- Run `yarn start` or `npm start` to start developing. \
+- Run `npm install` to install dependencies.
+- Run `npm start` to start developing. \
   Your URL should be similar to this example: \
   ```
   http://localhost:3000
@@ -19,7 +21,7 @@
 
 ### How to build the app
 
-- Run `yarn run build` or `npm run build`. \
+- Run `npm run build`. \
   This generates a static output inside `dist/`, which you can host on a static hosting service.
 
 ### Folder structure

--- a/examples/wordle/README.md
+++ b/examples/wordle/README.md
@@ -4,12 +4,14 @@
 
 - We recommend a Chromium-based web browser for local development with HTTP. \
   Safari enforces HTTPS; therefore, it doesn't allow localhost through HTTP.
+- All examples use `npm` as a package manager and `npx` as a package runner. \
+  If you prefer, you can install and use equivalent alternatives, such as `yarn` or `pnpm`.
 - For more information, visit our [developer documentation](https://developers.miro.com).
 
 ### How to start locally
 
-- Run `yarn` or `npm install` to install dependencies.
-- Run `yarn start` or `npm start` to start developing. \
+- Run `npm install` to install dependencies.
+- Run `npm start` to start developing. \
   Your URL should be similar to this example: \
   ```
   http://localhost:3000
@@ -19,7 +21,7 @@
 
 ### How to build the app
 
-- Run `yarn run build` or `npm run build`. \
+- Run `npm run build`. \
   This generates a static output inside `dist/`, which you can host on a static hosting service.
 
 ### Folder structure

--- a/examples/youtube-room/README.md
+++ b/examples/youtube-room/README.md
@@ -2,10 +2,12 @@
 
 **&nbsp;ℹ&nbsp;Note**:
 
-- We recommend a Chromium-based web browser for local development with HTTP. \
-  Safari enforces HTTPS; therefore, it doesn't allow localhost through HTTP.
 - Developing the app involves creating 2 separate apps, and testing them with different user sessions. \
   We recommend opening 2 browser sessions with different users to test the full functionality of the app.
+- We recommend a Chromium-based web browser for local development with HTTP. \
+  Safari enforces HTTPS; therefore, it doesn't allow localhost through HTTP.
+- All examples use `npm` as a package manager and `npx` as a package runner. \
+  If you prefer, you can install and use equivalent alternatives, such as `yarn` or `pnpm`.
 - For more information, visit our [developer documentation](https://developers.miro.com).
 
 This Miro Web SDK app shows you how you can sync multiple YouTube players across different user sessions. \
@@ -32,8 +34,8 @@ This app can be installed by multiple users. It contains the functionality that 
 
 ### How to start locally
 
-- Run `yarn` or `npm install` to install dependencies.
-- Run `yarn start` or `npm start` to start developing. \
+- Run `npm install` to install dependencies.
+- Run `npm start` to start developing. \
   Your URL should be similar to this example: \
   ```
   http://localhost:3000
@@ -84,7 +86,7 @@ After installing the participant app, no further setup in required. It will work
 
 When you're done developing your app, you will need to build your app before you can deploy it.
 
-- Run `yarn run build` or `npm run build`. \
+- Run `npm run build`. \
   This generates a static output inside `dist/`, which you can host on a static hosting service.
 
 ### How to deploy your app


### PR DESCRIPTION
- Remove all references to `yarn`.
- Add info about using `npm` and `npx` in all examples.

------

Context: https://miro.slack.com/archives/G017CRY59R6/p1654586766303429
 
[Mira Balani](https://miro.slack.com/team/U01PGBXMP8T) [Marco](https://miro.slack.com/team/U01SCTEA95M) this is wrong `yarn create miro-app@latest` , should be `yarn create miro-app`
 
I will update it, also any reason we have `yarn` in there?
I think we had this discussion earlier & we decided to stick to `npx` /`npm` only in the docs.