### PR TITLE
Add Python External OAuth example to app-examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ npx create-miro-app@latest
 | [nextjs-oauth](examples/nextjs-oauth)                      | This app demonstrates how to implement the Oauth 2.0 authorization code flow from Miro into a client side appliction built with Next.js .                                                                                                                                                                       |
 | [rest-stickies-csv](examples/rest-stickies-csv)            | This Node.js sample app uses server side rendering (Handlebars.js) to provide a lightweight, CRUD-oriented REST example in the browser for Miro's sticky notes and tags APIs.<br />It demonstrates a structured > unstructured use case via CSV import, creating Miro sticky notes with tags based on CSV data. |
 | [python-flask-starter](examples/rest/python-flask-starter) | This Python/Flask boilerplate will allow to start using the Miro REST API in a few minutes.<br />This sample implements the full Miro authorization (OAuth 2.0 with refresh token) flow.                                                                                                                        |
+| [python-external-oauth](examples/python-external-oauth)    | This Python/Flask app shows you how to set up an OAuth 2.0 flow with GitHub.<br />This sample allows you to log in with GitHub and post some details to a Miro Board.                                                                                                                                           |
 
 <p>&nbsp;</p>
 

--- a/examples/python-external-oauth/.gitignore
+++ b/examples/python-external-oauth/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/

--- a/examples/python-external-oauth/app.py
+++ b/examples/python-external-oauth/app.py
@@ -1,0 +1,70 @@
+from flask import Flask, render_template, url_for, redirect
+import requests
+from authlib.integrations.flask_client import OAuth
+
+app = Flask(__name__)
+oauth = OAuth(app)
+
+app.config["GITHUB_CLIENT_ID"] = "YOUR-GITHUB-CLIENT-ID"
+app.config["GITHUB_CLIENT_SECRET"] = "YOUR-GITHUB-CLIENT-SECRET"
+app.config["MIRO_ACCESS_TOKEN"] = "YOUR-MIRO-ACCESS-TOKEN"
+
+
+github = oauth.register(
+    name="github",
+    client_id=app.config["GITHUB_CLIENT_ID"],
+    client_secret=app.config["GITHUB_CLIENT_SECRET"],
+    access_token_url="https://github.com/login/oauth/access_token",
+    access_token_params=None,
+    authorize_url="https://github.com/login/oauth/authorize",
+    authorize_params=None,
+    api_base_url="https://api.github.com",
+    client_kwargs={"scope": "(no scope)"},
+)
+
+
+@app.route("/")
+def index():
+    return render_template("index.html")
+
+
+@app.route("/login/github")
+def github_login():
+    github = oauth.create_client("github")
+    redirect_uri = url_for("github_authorize", _external=True)
+    return github.authorize_redirect(redirect_uri)
+
+
+@app.route("/github/login/authorize")
+def github_authorize():
+    github = oauth.create_client("github")
+    token = github.authorize_access_token()
+    resp = github.get("user").json()
+    name = resp.get("name")
+    location = resp.get("location")
+    image_url = resp.get("avatar_url")
+    public_gist = str(resp.get("public_gists"))
+    public_repos = str(resp.get("public_repos"))
+    created_at = resp.get("created_at")
+
+    url = "https://api.miro.com/v2/boards/<your-board-id>/cards"
+
+    payload = {
+        "data": {
+            "title": f"GitHub account info for {name}",
+            "description": f"This account, which was created at {created_at}, belongs to {name}, an individual based in {location}. This owner has {public_gist} gists and {public_repos} repos. Get this avatar here: {image_url}",
+        },
+        "style": {"cardTheme": "#00FF00"},
+        "position": {"origin": "center", "x": 0, "y": 0},
+    }
+    headers = {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "Authorization": "Bearer " + app.config["MIRO_ACCESS_TOKEN"],
+    }
+
+    response = requests.post(url, json=payload, headers=headers)
+
+    print(f"\n{response.text}\n")
+
+    return "You are successfully logged in using GitHub"

--- a/examples/python-external-oauth/templates/index.html
+++ b/examples/python-external-oauth/templates/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Login to GitHub</title>
+    <!-- BootstrapCSS and Font Awesome Icons-->
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor"
+      crossorigin="anonymous"
+    />
+    <script src="https://use.fontawesome.com/a29051b563.js"></script>
+
+    <!-- Customs styles -->
+  </head>
+  <body>
+    <a
+      href="http://127.0.0.1:5000/login/github"
+      id="github-button"
+      class="btn btn-dark btn-lg btn-block"
+    >
+      <i class="fa fa-github"></i> Sign in with GitHub
+    </a>
+  </body>
+</html>


### PR DESCRIPTION
This PR contains the code for a guide contributed to Miro's documentation from one of our partners. 

This app demonstrates how to set up an OAuth2 flow from GitHub, inside an app that uses Miro's REST API