### PR TITLE
Add Plant UML entry to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,15 +50,16 @@ npx create-miro-app@latest
 | [rest-stickies-csv](examples/rest-stickies-csv)                   | This Node.js sample app uses server side rendering (Handlebars.js) to provide a lightweight, CRUD-oriented REST example in the browser for Miro's sticky notes and tags APIs.<br />It demonstrates a structured > unstructured use case via CSV import, creating Miro sticky notes with tags based on CSV data. |
 | [python-flask-starter](examples/rest/python-flask-starter)        | This Python/Flask boilerplate will allow to start using the Miro REST API in a few minutes.<br />This sample implements the full Miro authorization (OAuth 2.0 with refresh token) flow.                                                                                                                        |
 | [python-external-oauth](examples/python-external-oauth)           | This Python/Flask app shows you how to set up an OAuth 2.0 flow with GitHub.<br />This sample allows you to log in with GitHub and post some details to a Miro Board.                                                                                                                                           |
-| [enterprise-team-management](examples/enterprise-team-management) | This Node.js sample demonstrates how to manage teams and organizations within Miro using Miro's REST API.<br />_Note: This example requires you to have an [Enterprise Team account](https://miro.com/enterprise/) in Miro._ |
+| [enterprise-team-management](examples/enterprise-team-management) | This Node.js sample demonstrates how to manage teams and organizations within Miro using Miro's REST API.<br />_Note: This example requires you to have an [Enterprise Team account](https://miro.com/enterprise/) in Miro._                                                                                    |
 
 <p>&nbsp;</p>
 
 ### Full Stack Apps
 
-|                                             | Description                                                                                                                     |
-| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| [github-appcards](examples/github-appcards) | This full stack example shows how to build an integration with GitHub that syncs data between GitHub issues and Miro app cards. |
+|                                                       | Description                                                                                                                     |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| [github-appcards](examples/github-appcards)           | This full stack example shows how to build an integration with GitHub that syncs data between GitHub issues and Miro app cards. |
+| [plant-uml](https://github.com/miroapp/miro-plantuml) | This full stack example shows import [Plant UML](https://plantuml.com/) diagrams into Miro as editable board items.             |
 
 <p>&nbsp;</p>
 


### PR DESCRIPTION
This PR adds an entry to the `app-examples` readme containing a link to Miro's Plant UML example