### PR TITLE
Use panel instead of popup in the example

### DIFF
--- a/examples/nextjs-full-stack/README.md
+++ b/examples/nextjs-full-stack/README.md
@@ -30,7 +30,7 @@ First, make sure you've handled the prerequisites in full:
   - Continue to scroll down to 'Redirect URI for OAuth2.0' and paste in the following redirect url: `http://localhost:3000/api/redirect/`
   - Click 'Options'. \
     From the drop-down menu select 'Use this URI for SDK authorization'
-  - Lastly, scroll down to 'Permissions' and check off the `Board:Read` and `Board:Write` scopes
+  - Lastly, scroll down to 'Permissions' and check off the `board:read`, `board:write` and `webcam:record` scopes
 
 Next, we can start working directly with this sample app:
 

--- a/examples/nextjs-full-stack/pages/index.jsx
+++ b/examples/nextjs-full-stack/pages/index.jsx
@@ -78,7 +78,13 @@ export default function Main({ boardId }) {
     canvas.height = height;
 
     canvas.getContext("2d").drawImage(video, 0, 0, width, height);
-    canvas.toBlob((blob) => uploadBlob(blob, boardId));
+    canvas.toBlob(async (blob) => {
+      try {
+        await uploadBlob(blob, boardId);
+      } finally {
+        e.target.disabled = false;
+      }
+    });
   };
 
   return (
@@ -88,7 +94,6 @@ export default function Main({ boardId }) {
       </Head>
 
       <div>
-        <h1>Upload camera image</h1>
         <div>
           <video ref={videoRef} style={{ width: "100%", maxWidth: "400px" }}>
             Video stream not available.

--- a/examples/nextjs-full-stack/pages/trigger.jsx
+++ b/examples/nextjs-full-stack/pages/trigger.jsx
@@ -4,12 +4,10 @@ import Head from "next/head";
 export default function () {
   useEffect(() => {
     window.miro.board.ui.on("icon:click", async () => {
-      // open popup with the video stream
-      window.open(
-        `/?boardId=${(await window.miro.board.getInfo()).id}`,
-        "cameraCapture",
-        "popup"
-      );
+      // open panel with the video stream
+      window.miro.board.ui.openPanel({
+        url: `/?boardId=${(await window.miro.board.getInfo()).id}`,
+      });
     });
   }, []);
 


### PR DESCRIPTION
By adding webcam:record permissions we can have the camera preview in the panel iframe instead of having to open a popup.