### PR TITLE
DX 1472 Update cross-reference links and cleanup after decoupling 'create dev team' docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <img alt="Miro Developer Platform" src="https://github.com/miroapp/app-examples/raw/main/assets/Banner.png" />
 
-Welcome to Miro App Examples! In this repository you can find examples of apps built on top of the Miro Developer Platform 2.0.<br />
+Welcome to Miro App Examples! In this repository you can find examples of apps built on top of the Miro Developer Platform 2.0. \
 Make sure you visit our [developer documentation](https://developers.miro.com) to learn more.
 
 **&nbsp;ℹ&nbsp;Note**:
@@ -17,7 +17,7 @@ Make sure you visit our [developer documentation](https://developers.miro.com) t
 
 ### Miro Web SDK
 
-The fastest way to bootstrap a new app is by using [`create-miro-app`](https://www.npmjs.com/package/create-miro-app).<br />
+The fastest way to bootstrap a new app is by using [`create-miro-app`](https://www.npmjs.com/package/create-miro-app). \
 To get started, run the following command:
 
 ```shell
@@ -46,24 +46,24 @@ npx create-miro-app@latest
 | [python-oauth](examples/python-oauth)                             | This Python sample demonstrates how to implement the Oauth 2.0 authorization code flow in Miro.                                                                                                                                                                                                                 |
 | [node-oauth](examples/node-oauth)                                 | This Node.js sample demonstrates how to implement the Oauth 2.0 authorization code flow in Miro and make an API request to a Miro endpoint.                                                                                                                                                                     |
 | [node-passport-oauth](examples/node-passport-oauth)               | This Node.js sample demonstrates how to implement the Oauth 2.0 authorization code flow in Miro and make an API request to a Miro endpoint using [Passport.js](https://www.passportjs.org/).                                                                                                                    |
-| [nextjs-oauth](examples/nextjs-oauth)                             | This app demonstrates how to implement the Oauth 2.0 authorization code flow from Miro into a client side appliction built with Next.js .                                                                                                                                                                       |
+| [nextjs-oauth](examples/nextjs-oauth)                             | This app demonstrates how to implement the Oauth 2.0 authorization code flow from Miro into a client side application built with Next.js.                                                                                                                                                                       |
 | [node-stickies-csv](examples/node-stickies-csv)                   | This Node.js sample app uses server side rendering (Handlebars.js) to provide a lightweight, CRUD-oriented REST example in the browser for Miro's sticky notes and tags APIs.<br />It demonstrates a structured > unstructured use case via CSV import, creating Miro sticky notes with tags based on CSV data. |
 | [python-flask-starter](examples/rest/python-flask-starter)        | This Python/Flask boilerplate will allow to start using the Miro REST API in a few minutes.<br />This sample implements the full Miro authorization (OAuth 2.0 with refresh token) flow.                                                                                                                        |
 | [python-external-oauth](examples/python-external-oauth)           | This Python/Flask app shows you how to set up an OAuth 2.0 flow with GitHub.<br />This sample allows you to log in with GitHub and post some details to a Miro Board.                                                                                                                                           |
-| [enterprise-team-management](examples/enterprise-team-management) | This Node.js sample demonstrates how to manage teams and organizations within Miro using Miro's REST API.<br />_Note: This example requires you to have an [Enterprise Team account](https://miro.com/enterprise/) in Miro._                                                                                    |
+| [enterprise-team-management](examples/enterprise-team-management) | This Node.js sample demonstrates how to manage teams and organizations within Miro using Miro's REST API.<br />ℹ️ _This example requires an Enterprise plan subscription and an [Enterprise Team account](https://miro.com/enterprise/)._                                                                       |
 
 <p>&nbsp;</p>
 
-### Full Stack Apps
+### Full stack apps
 
-|                                                       | Description                                                                                                                       |
-| ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| [github-appcards](examples/github-appcards)           | This full stack example shows how to build an integration with GitHub that syncs data between GitHub issues and Miro app cards.   |
-| [plant-uml](https://github.com/miroapp/miro-plantuml) | This full stack example shows import [Plant UML](https://plantuml.com/) diagrams into Miro as editable board items.               |
-| [nextjs](examples/nextjs-full-stack)                  | This full stack example shows a Next.js application that will upload camera image to the Miro board using SDK and API integration |
+|                                                       | Description                                                                                                                               |
+| ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| [github-appcards](examples/github-appcards)           | This full stack example shows how to build an integration with GitHub that syncs data between GitHub issues and Miro app cards.           |
+| [plant-uml](https://github.com/miroapp/miro-plantuml) | This full stack example shows importing [Plant UML](https://plantuml.com/) diagrams into Miro as editable board items.                    |
+| [nextjs](examples/nextjs-full-stack)                  | This full stack example shows a Next.js application that uploads a camera image to the Miro board using Web SDK and REST API integration. |
 
 <p>&nbsp;</p>
 
 If you'd like to contribute your own app or idea, visit our [contributing guide](CONTRIBUTING.md) to get started.
 
-_Interested in learning more? Feel free to join our [Developer Community](https://bit.ly/miro-developers) to chat with other Miro Developers!_
+💡 _Interested in learning more? Feel free to join our [Developer Community](https://bit.ly/miro-developers) to chat with other Miro Developers!_

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ npx create-miro-app@latest
 |                                                       | Description                                                                                                                               |
 | ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
 | [github-appcards](examples/github-appcards)           | This full stack example shows how to build an integration with GitHub that syncs data between GitHub issues and Miro app cards.           |
-| [plant-uml](https://github.com/miroapp/miro-plantuml) | This full stack example shows importing [Plant UML](https://plantuml.com/) diagrams into Miro as editable board items.                    |
+| [plant-uml](https://github.com/miroapp/miro-plantuml) | This full stack example shows how to import [Plant UML](https://plantuml.com/) diagrams into Miro as editable board items.                    |
 | [nextjs](examples/nextjs-full-stack)                  | This full stack example shows a Next.js application that uploads a camera image to the Miro board using Web SDK and REST API integration. |
 
 <p>&nbsp;</p>

--- a/examples/asset-search/README.md
+++ b/examples/asset-search/README.md
@@ -16,7 +16,7 @@
   ```
   http://localhost:3000
   ```
-- Paste the URL under **App URL** in your [app settings](https://developers.miro.com/docs/build-your-first-hello-world-app#step-3-create-your-app-in-miro).
+- Paste the URL under **App URL** in your [app settings](https://developers.miro.com/docs/build-your-first-hello-world-app#step-2-create-your-app-in-miro).
 - Open a board; you should see your app in the app toolbar or in the **Apps** panel.
 
 ### How to build the app

--- a/examples/blob-maker/README.md
+++ b/examples/blob-maker/README.md
@@ -18,7 +18,7 @@
   ```
   http://localhost:3000
   ```
-- Paste the URL under **App URL** in your [app settings](https://developers.miro.com/docs/build-your-first-hello-world-app#step-3-create-your-app-in-miro).
+- Paste the URL under **App URL** in your [app settings](https://developers.miro.com/docs/build-your-first-hello-world-app#step-2-create-your-app-in-miro).
 - Open a board; you should see your app in the app toolbar or in the **Apps** panel.
 
 ### How to start with Glitch
@@ -32,7 +32,7 @@
 - After the app starts up, it will have a unique URL that will serve the app over HTTPS. \
   Click **Preview** in the bottom bar, and then **Preview in a new window**.
 - You should see **Great, your app is running locally!**. Copy the URL.
-- Paste the URL under **App URL** in your [app settings](https://developers.miro.com/docs/build-your-first-hello-world-app#step-3-create-your-app-in-miro).
+- Paste the URL under **App URL** in your [app settings](https://developers.miro.com/docs/build-your-first-hello-world-app#step-2-create-your-app-in-miro).
 - Open a board; you should see your app in the app toolbar or in the **Apps** panel.
 
 ### How to build the app

--- a/examples/blob-maker/index.html
+++ b/examples/blob-maker/index.html
@@ -21,7 +21,7 @@
       <div class="cs1 ce12">
         <a
           class="button button-primary"
-          href="https://miro.com/app/dashboard/?createDevTeam=1"
+          href="https://developers.miro.com/docs/create-a-developer-team"
           target="_blank"
         >
           Create a Developer team

--- a/examples/calendar/README.md
+++ b/examples/calendar/README.md
@@ -16,7 +16,7 @@
   ```
   http://localhost:3000
   ```
-- Paste the URL under **App URL** in your [app settings](https://developers.miro.com/docs/build-your-first-hello-world-app#step-3-create-your-app-in-miro).
+- Paste the URL under **App URL** in your [app settings](https://developers.miro.com/docs/build-your-first-hello-world-app#step-2-create-your-app-in-miro).
 - Open a board; you should see your app in the app toolbar or in the **Apps** panel.
 
 ### How to build the app

--- a/examples/connect-firebase/README.md
+++ b/examples/connect-firebase/README.md
@@ -35,7 +35,7 @@ const firebaseConfig = {
   ```
   http://localhost:3000
   ```
-- Paste the URL under **App URL** in your [app settings](https://developers.miro.com/docs/build-your-first-hello-world-app#step-3-create-your-app-in-miro).
+- Paste the URL under **App URL** in your [app settings](https://developers.miro.com/docs/build-your-first-hello-world-app#step-2-create-your-app-in-miro).
 - Open a board; you should see your app in the app toolbar or in the **Apps** panel.
 
 ### How to build the app

--- a/examples/connect-firebase/index.html
+++ b/examples/connect-firebase/index.html
@@ -21,7 +21,7 @@
       <div class="cs1 ce12">
         <a
           class="button button-primary"
-          href="https://developers.miro.com/docs/build-your-first-hello-world-app#step-2-create-a-developer-team-in-miro"
+          href="https://developers.miro.com/docs/create-a-developer-team"
           target="_blank"
         >
           Create a Developer team

--- a/examples/drag-and-drop/README.md
+++ b/examples/drag-and-drop/README.md
@@ -16,7 +16,7 @@
   ```
   http://localhost:3000
   ```
-- Paste the URL under **App URL** in your [app settings](https://developers.miro.com/docs/build-your-first-hello-world-app#step-3-create-your-app-in-miro).
+- Paste the URL under **App URL** in your [app settings](https://developers.miro.com/docs/build-your-first-hello-world-app#step-2-create-your-app-in-miro).
 - Open a board; you should see your app in the app toolbar or in the **Apps** panel.
 
 ### How to build the app

--- a/examples/github-appcards/README.md
+++ b/examples/github-appcards/README.md
@@ -17,7 +17,7 @@
   ```
   http://localhost:3000
   ```
-- Paste the URL under **App URL** in your [app settings](https://developers.miro.com/docs/build-your-first-hello-world-app#step-3-create-your-app-in-miro).
+- Paste the URL under **App URL** in your [app settings](https://developers.miro.com/docs/build-your-first-hello-world-app#step-2-create-your-app-in-miro).
 - Open a board; you should see your app in the app toolbar or in the **Apps** panel.
 
 ### How to build the app

--- a/examples/nextjs-full-stack/README.md
+++ b/examples/nextjs-full-stack/README.md
@@ -14,7 +14,7 @@ This example also stores your access and refresh tokens in your browsers cookies
 ## Prerequisites
 
 1. Create a [Developer team in Miro](https://developers.miro.com/docs/create-a-developer-team).
-2. Create an [app in Miro](https://developers.miro.com/docs/build-your-first-hello-world-app#step-3-create-your-app-in-miro).
+2. Create an [app in Miro](https://developers.miro.com/docs/build-your-first-hello-world-app#step-2-create-your-app-in-miro).
 3. Create a board in Miro that you'd like to manipulate with the REST API.
 
 ## How to start

--- a/examples/nextjs-full-stack/README.md
+++ b/examples/nextjs-full-stack/README.md
@@ -6,10 +6,10 @@ This example also stores your access and refresh tokens in your browsers cookies
 
 ## Stack
 
-- [x] React
-- [x] Next.js
-- [x] Miro API client
-- [x] Mirotone (styling)
+- [x] [React](https://reactjs.org/)
+- [x] [Next.js](https://nextjs.org/)
+- [x] [Miro Node.js API client](https://developers.miro.com/docs/miro-nodejs-readme)
+- [x] [Mirotone](https://www.mirotone.xyz/css) (styling)
 
 ## Prerequisites
 

--- a/examples/nextjs-full-stack/README.md
+++ b/examples/nextjs-full-stack/README.md
@@ -1,4 +1,4 @@
-# Miro Full Stack Example
+# Miro full stack app example
 
 This sample app demonstrates the use of the Miro REST API and Web SDK. After configuring your project outlined in the Prerequisites section, this app allows you to authenticate yourself with your Miro account, and use the related access tokens to make REST API calls via the Miro Developer Platform.
 
@@ -6,37 +6,39 @@ This example also stores your access and refresh tokens in your browsers cookies
 
 ## Stack
 
-- React
-- Next JS
-- Miro API Client
-- Mirotone (styling)
+- [x] React
+- [x] Next.js
+- [x] Miro API client
+- [x] Mirotone (styling)
 
 ## Prerequisites
 
-1. Create a [developer team in Miro](https://miro.com/app/dashboard/?createDevTeam=1)
-2. Create an [app in Miro](https://miro.com/app/settings/user-profile/apps)
-3. Create a board in Miro that you'd like to manipulate using our REST API
+1. Create a [Developer team in Miro](https://developers.miro.com/docs/create-a-developer-team).
+2. Create an [app in Miro](https://developers.miro.com/docs/build-your-first-hello-world-app#step-3-create-your-app-in-miro).
+3. Create a board in Miro that you'd like to manipulate with the REST API.
 
 ## How to start
 
-First, make sure you've handled the prerequisites in full:
+First, make sure you handled the prerequisites:
 
-- Create a [developer team in Miro](https://miro.com/app/dashboard/?createDevTeam=1)
-  - Click the link above, to create a developer team under your account
-- Create an [app in Miro](https://miro.com/app/settings/user-profile/apps)
-  - From your developer team in Miro, click the "Build Apps" button in the team dashboard UI
-  - Name your app, click 'create'
-  - Scroll down to 'App Credentials' and copy the client id and client secret — we will use these below in step 4
-  - Continue to scroll down to 'Redirect URI for OAuth2.0' and paste in the following redirect url: `http://localhost:3000/api/redirect/`
-  - Click 'Options'. \
-    From the drop-down menu select 'Use this URI for SDK authorization'
-  - Lastly, scroll down to 'Permissions' and check off the `board:read`, `board:write` and `webcam:record` scopes
+- Create a [Developer team in Miro](https://developers.miro.com/docs/create-a-developer-team).
+- Create an [app in Miro](https://miro.com/app/settings/user-profile/apps):
+  - From your developer team in Miro, click the **Build Apps** button in the team dashboard UI.
+  - Name your app, and click **Create**.
+  - Scroll down to **App Credentials**, and copy client ID and client secret: you'll use them later in step 4.
+  - Scroll further down to **Redirect URI for OAuth2.0**, and paste the following redirect URL: `http://localhost:3000/api/redirect/`
+  - Click **Options**. \
+    From the drop-down menu select **Use this URI for SDK authorization**.
+  - Lastly, scroll down to **Permissions**, and select the following permissions:
+    - `board:read`
+    - `board:write`
+    - `webcam:record`
 
-Next, we can start working directly with this sample app:
+Now you can start working directly with the sample app:
 
-1. Clone or download repository
-2. `cd` to root folder
-3. Run `yarn install` to install dependencies.
+1. Clone or download the app repository.
+2. `cd` to the project root folder.
+3. Run `yarn install` to install the dependencies.
 4. Create a `.env` file in the root folder, and set the following variables:
 
 ```
@@ -45,11 +47,15 @@ MIRO_CLIENT_SECRET={YOUR_CLIENT_SECRET}
 MIRO_REDIRECT_URL=http://localhost:3000/api/redirect/
 ```
 
-5. Run `yarn dev` to start the local server
+5. Run `yarn dev` to start the local server.
 
-Once your server is up and running, go to [Miro.com](https://miro.com), open a board in your developer team and start the app by clicking on your App icon in the toolbar on the left.
+Once your server is up and running:
 
-## Folder Structure
+1. Go to [Miro.com](https://miro.com).
+2. Open a board in your Developer team.
+3. To start the app, click the corresponding app icon in the app toolbar on the left.
+
+## Folder structure
 
 ```
 .

--- a/examples/nextjs-oauth/README.md
+++ b/examples/nextjs-oauth/README.md
@@ -6,11 +6,11 @@ This example also stores your access and refresh tokens in your browsers cookies
 
 ## Stack
 
-- [x] React
-- [x] Next.js
-- [x] Axios
-- [x] Miro REST API
-- [x] Mirotone (styling)
+- [x] [React](https://reactjs.org/)
+- [x] [Next.js](https://nextjs.org/)
+- [x] [Axios](https://axios-http.com/)
+- [x] [Miro REST API](https://developers.miro.com/reference/api-reference)
+- [x] [Mirotone](https://www.mirotone.xyz/css) (styling)
 
 ## Prerequisites
 
@@ -50,7 +50,7 @@ clientSecret={YOUR_CLIENT_SECRET}
 redirectURL=http://localhost:3000/api/redirect/
 ```
 
-1. Go to `constants.js`, and add the `boardId` of the Miro board you'd like to use/modify.
+1. Go to [`constants.js`](./constants.js), and add the `boardId` of the Miro board you'd like to use/modify.
 2. Run `yarn dev` to start the local server.
 
 Once your server is up and running, go to `http://localhost:3000/` in your browser. \

--- a/examples/nextjs-oauth/README.md
+++ b/examples/nextjs-oauth/README.md
@@ -15,7 +15,7 @@ This example also stores your access and refresh tokens in your browsers cookies
 ## Prerequisites
 
 1. Create a [developer team in Miro](https://developers.miro.com/docs/create-a-developer-team).
-2. Create an [app in Miro](https://developers.miro.com/docs/build-your-first-hello-world-app#step-3-create-your-app-in-miro).
+2. Create an [app in Miro](https://developers.miro.com/docs/build-your-first-hello-world-app#step-2-create-your-app-in-miro).
 3. Create a board in Miro that you'd like to manipulate with the REST API.
 
 ## How to start

--- a/examples/nextjs-oauth/README.md
+++ b/examples/nextjs-oauth/README.md
@@ -1,4 +1,4 @@
-# Miro Full Stack Example
+# Miro full stack app example
 
 This sample app demonstrates the use of the Miro REST API and OAuth authorization. After configuring your project outlined in the Prerequisites section, this app allows you to authenticate yourself with your Miro account, and use the related access tokens to make REST API calls via the Miro Developer Platform.
 
@@ -7,37 +7,42 @@ This example also stores your access and refresh tokens in your browsers cookies
 ## Stack
 
 - [x] React
-- [x] Next JS
+- [x] Next.js
 - [x] Axios
 - [x] Miro REST API
 - [x] Mirotone (styling)
 
 ## Prerequisites
 
-1. Create a [developer team in Miro](https://miro.com/app/dashboard/?createDevTeam=1)
-2. Create an [app in Miro](https://miro.com/app/settings/user-profile/apps)
-3. Create a board in Miro that you'd like to manipulate using our REST API
+1. Create a [developer team in Miro](https://developers.miro.com/docs/create-a-developer-team).
+2. Create an [app in Miro](https://developers.miro.com/docs/build-your-first-hello-world-app#step-3-create-your-app-in-miro).
+3. Create a board in Miro that you'd like to manipulate with the REST API.
 
 ## How to start
 
-First, make sure you've handled the prerequisites in full:
+First, make sure you handled the prerequisites:
 
-- Create a [developer team in Miro](https://miro.com/app/dashboard/?createDevTeam=1)
-  - Click the link above, to create a developer team under your account
+- Create a [Developer team in Miro](https://developers.miro.com/docs/create-a-developer-team).
 - Create an [app in Miro](https://miro.com/app/settings/user-profile/apps)
-  - From your developer team in Miro, click the "Build Apps" button in the team dashboard UI
-  - Name your app, click 'create'
-  - Scroll down to 'App Credentials' and copy the client id and client secret — we will use these below in step 4
-  - Continue to scroll down to 'Redirect URI for OAuth2.0' and paste in the following redirect url: `http://localhost:3000/api/redirect/`
-  - Lastly, scroll down to 'Permissions' and check off the `Board:Read` and `Board:Write` scopes
-- Navigate back to your developer team dashboard and create a new board in Miro. Make note of the board ID in the URL of the new board — we will use this below in step 5
 
-Next, we can start working directly with this sample app:
+- From your developer team in Miro, click the **Build Apps** button in the team dashboard UI.
+- Name your app, and click **Create**.
+- Scroll down to **App Credentials**, and copy client ID and client secret: you'll use them later in step 4.
+- Scroll further down to **Redirect URI for OAuth2.0**, and paste the following redirect URL: `http://localhost:3000/api/redirect/`
+- Click **Options**. \
+  From the drop-down menu select **Use this URI for SDK authorization**.
+- Lastly, scroll down to **Permissions**, and select the following permissions:
+  - `board:read`
+  - `board:write`
+- Go back to your Developer team dashboard, and create a new board in Miro.
+- Make a note of the board ID in the URL of the new board: you'll use it later in step 5.
 
-1. Clone or download repo
-2. `cd` to root folder
-3. Run `yarn install` to install dependencies.
-4. Create a .env file in the root folder, and set the following variables:
+Now you can start working directly with the sample app:
+
+1. Clone or download the app repository.
+2. `cd` to the project root folder.
+3. Run `yarn install` to install the dependencies.
+4. Create a `.env` file in the root folder, and set the following variables:
 
 ```
 clientID={YOUR_CLIENT_ID)
@@ -45,12 +50,13 @@ clientSecret={YOUR_CLIENT_SECRET}
 redirectURL=http://localhost:3000/api/redirect/
 ```
 
-5. Navigate to `constants.js` and add the `boardId` of the Miro Board you'd like to leverage/modify
-6. Run `yarn dev` to start the local server
+1. Go to `constants.js`, and add the `boardId` of the Miro board you'd like to use/modify.
+2. Run `yarn dev` to start the local server.
 
-Once your server is up and running, navigate to `http://localhost:3000/` in your browser. If the project is running successfully, you should see a 'Sign in' button in the UI.
+Once your server is up and running, go to `http://localhost:3000/` in your browser. \
+If the project is running successfully, you should see a **Sign in** button in the UI.
 
-## Folder Structure
+## Folder structure
 
 ```
 .

--- a/examples/stickynotes-to-shapes/README.md
+++ b/examples/stickynotes-to-shapes/README.md
@@ -16,7 +16,7 @@
   ```
   http://localhost:3000
   ```
-- Paste the URL under **App URL** in your [app settings](https://developers.miro.com/docs/build-your-first-hello-world-app#step-3-create-your-app-in-miro).
+- Paste the URL under **App URL** in your [app settings](https://developers.miro.com/docs/build-your-first-hello-world-app#step-2-create-your-app-in-miro).
 - Open a board; you should see your app in the app toolbar or in the **Apps** panel.
 
 ### How to build the app

--- a/examples/template-builder/README.md
+++ b/examples/template-builder/README.md
@@ -16,7 +16,7 @@
   ```
   http://localhost:3000
   ```
-- Paste the URL under **App URL** in your [app settings](https://developers.miro.com/docs/build-your-first-hello-world-app#step-3-create-your-app-in-miro).
+- Paste the URL under **App URL** in your [app settings](https://developers.miro.com/docs/build-your-first-hello-world-app#step-2-create-your-app-in-miro).
 - Open a board; you should see your app in the app toolbar or in the **Apps** panel.
 
 ### How to build the app

--- a/examples/wordle/README.md
+++ b/examples/wordle/README.md
@@ -16,7 +16,7 @@
   ```
   http://localhost:3000
   ```
-- Paste the URL under **App URL** in your [app settings](https://developers.miro.com/docs/build-your-first-hello-world-app#step-3-create-your-app-in-miro).
+- Paste the URL under **App URL** in your [app settings](https://developers.miro.com/docs/build-your-first-hello-world-app#step-2-create-your-app-in-miro).
 - Open a board; you should see your app in the app toolbar or in the **Apps** panel.
 
 ### How to build the app

--- a/examples/youtube-room/README.md
+++ b/examples/youtube-room/README.md
@@ -40,9 +40,9 @@ This app can be installed by multiple users. It contains the functionality that 
   ```
   http://localhost:3000
   ```
-- [Create a new Miro app](https://developers.miro.com/docs/build-your-first-hello-world-app#step-3-create-your-app-in-miro) for the facilitator app component.
+- [Create a new Miro app](https://developers.miro.com/docs/build-your-first-hello-world-app#step-2-create-your-app-in-miro) for the facilitator app component.
 - Paste `http://localhost:3000/facilitator` in the `App URL` box in your Facilitator app settings.
-- [Create a new Miro app](https://developers.miro.com/docs/build-your-first-hello-world-app#step-3-create-your-app-in-miro) for the participant app component.
+- [Create a new Miro app](https://developers.miro.com/docs/build-your-first-hello-world-app#step-2-create-your-app-in-miro) for the participant app component.
 - Paste `http://localhost:3000/participant` in the `App URL` box in your participant app settings.
 - Open a board and click the three dots (...) or the chevron (>>) on the left toolbar. You should see the Miro calendar app.
 

--- a/examples/youtube-room/facilitator.html
+++ b/examples/youtube-room/facilitator.html
@@ -18,7 +18,7 @@
       <div class="cs1 ce12">
         <a
           class="button button-primary"
-          href="https://miro.com/app/dashboard/?createDevTeam=1"
+          href="https://developers.miro.com/docs/create-a-developer-team"
           target="_blank"
         >
           Create a Developer team

--- a/examples/youtube-room/index.html
+++ b/examples/youtube-room/index.html
@@ -21,7 +21,7 @@
       <div class="cs1 ce12">
         <a
           class="button button-primary"
-          href="https://miro.com/app/dashboard/?createDevTeam=1"
+          href="https://developers.miro.com/docs/create-a-developer-team"
           target="_blank"
         >
           Create a Developer team

--- a/examples/youtube-room/participant.html
+++ b/examples/youtube-room/participant.html
@@ -18,7 +18,7 @@
       <div class="cs1 ce12">
         <a
           class="button button-primary"
-          href="https://miro.com/app/dashboard/?createDevTeam=1"
+          href="https://developers.miro.com/docs/create-a-developer-team"
           target="_blank"
         >
           Create a Developer team


### PR DESCRIPTION
Clean-up PR:
* Update cross-reference links decoupling *create dev team* docs.
* Make style consistent across sample app Readme files.
* the *Create Developer team* button on the sample app panel points to the docs instead of the *Create Dev team* feature of the Miro user account. Some users found it an awkward context switch from the app to the settings, so we take them to the docs, instead.

I'll also open similar PRs for the `create-miro-app` repo and the Node.js API client repo.