### PR TITLE
Run linter checks on pull requests

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -2,6 +2,8 @@ name: Code Quality
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,6 +1,8 @@
 name: Code Quality
 
-on: push
+on:
+  push:
+  pull_request:
 
 jobs:
   run-linters:


### PR DESCRIPTION
This should fix the issue of linters not running on PRs made from forks