### PR TITLE
Execute event handler registration only once

### DIFF
--- a/examples/drag-and-drop/src/App.tsx
+++ b/examples/drag-and-drop/src/App.tsx
@@ -26,7 +26,7 @@ function App() {
   // Register the drop event handler once.
   useEffect(() => {
     board.ui.on("drop", drop);
-  });
+  }, []);
 
   return (
     <div className="main">


### PR DESCRIPTION
### Motivation
Currently the event handler registration runs only ones if the app is not re-rendered.

If someone extended this app example and added some dynamic components a new event handler would be registered on every re-render.

### Proposed changes
Use empty dependencies list in useEffect in order to execute event handler registration only once regardless of app re-rendering.