### PR TITLE
add netlify to nextjs README and update node stickies csv to use localhost

### DIFF
--- a/examples/nextjs-oauth/README.md
+++ b/examples/nextjs-oauth/README.md
@@ -37,7 +37,7 @@ https://github.com/miroapp/app-examples/assets/10428517/cdda8f44-bf25-420e-ae84-
 - Your development environment includes [Node.js 14.13](https://nodejs.org/en/download) or a later version.
 - All examples use `npm` as a package manager and `npx` as a package runner.
 
-# ☁️ Deploy the app on AWS or Azure <a name="deploy"></a>
+# ☁️ Deploy the app on AWS, Azure, or Netlify <a name="deploy"></a>
 
 If you want to understand how to deploy the app to AWS Amplify or Azure (Static Web Apps), please watch the video below. Otherwise,
 skip to the next section to see how to run this locally.
@@ -47,6 +47,10 @@ skip to the next section to see how to run this locally.
 If you want to understand how to deploy the app to Microsoft Azure (Static Web Apps) please watch the video below.
 
 [![Deploy the App to Microsoft Azure](https://img.youtube.com/vi/5Fq9chq0t4I/0.jpg)](https://youtu.be/5Fq9chq0t4I)
+
+If you want to understand how to deploy the app to Netlify please watch the video below.
+
+[![Deploy the App to Netlify](https://img.youtube.com/vi/pLsOUNfh-TU/0.jpg)](https://youtu.be/pLsOUNfh-TU)
 
 # 🏃🏽‍♂️ Run the app locally <a name="run"></a>
 

--- a/examples/node-stickies-csv/README.md
+++ b/examples/node-stickies-csv/README.md
@@ -75,11 +75,13 @@ MIRO_BOARD_ID=<YOUR_MIRO_BOARD_ID>
 
 https://github.com/miroapp/app-examples/assets/10428517/1e6862de-8617-46ef-b265-97ff1cbfe8bf
 
-6. Go to your developer team, and open your boards.
-7. Click on the plus icon from the bottom section of your left sidebar. If you hover over it, it will say `More apps`.
-8. Search for your app `Node.js Stickies to CSV` or whatever you chose to name it. Click on your app to use it, as shown in the video below.
+6. Go to the developer team which you installed the app on, and open the board with the board ID matching your board from the .env file: `MIRO_BOARD_ID=<YOUR_MIRO_BOARD_ID>`.
 
 https://github.com/horeaporutiu/app-examples-template/assets/10428517/b23d9c4c-e785-43f9-a72e-fa5d82c7b019
+
+7. Next, go to `localhost:8000`, and click on `Authorize App`.
+
+8. Go through the authorization process, then click on `List Stickies` or any of the other buttons at the top to interact with the app.
 
 # 🗂️ Folder structure <a name="folder"></a>
 


### PR DESCRIPTION
- Update next.js app to show deployment option of Netlify
- Update node stickies CSV to use localhost in the instructions. Launching via the app toolbar doesn't work so it's a bad dev experience currently without this change