### PR TITLE
standardizing manifest to be yaml for easy copy paste

### DIFF
--- a/examples/calendar/README.md
+++ b/examples/calendar/README.md
@@ -51,14 +51,17 @@ This app allows you to create a calendar consisting of shapes and text for the g
    http://localhost:3000
    ```
 3. Open the [app manifest editor](https://developers.miro.com/docs/manually-create-an-app#step-2-configure-your-app-in-miro) by clicking **Edit in Manifest**. \
-   In the app manifest editor, configure the app as follows:
+   In the app manifest editor, configure the app as follows, and then click save:
 
-   - [`sdkUri`](https://developers.miro.com/docs/app-manifest#sdkuri): assign `http://localhost:3000` as a value for this property. \
-     It defines the entry point of the app, and it corresponds to the URL of the server that the app runs on.
-   - [`scopes`](https://developers.miro.com/docs/app-manifest#scopes): add the permission scopes that users need to grant the app when they install it. \
-     To enable the app to read from and write to the board, add the following permissions:
-     - `boards:read`
-     - `boards:write`
+```yaml
+# See https://developers.miro.com/docs/app-manifest on how to use this
+appName: Calendar
+sdkVersion: SDK_V2
+sdkUri: http://localhost:3000
+scopes:
+  - boards:read
+  - boards:write
+```
 
 4. Go back to your app home page, and under the `Permissions` section, you will see a blue button that says `Install app and get OAuth token`. Click that button. Then click on `Add` as shown in the video below. <b>In the video we install a different app, but the process is the same regardless of the app.</b>
 

--- a/examples/connect-firebase/README.md
+++ b/examples/connect-firebase/README.md
@@ -67,14 +67,17 @@ const firebaseConfig = {
    http://localhost:3000
    ```
 4. Open the [app manifest editor](https://developers.miro.com/docs/manually-create-an-app#step-2-configure-your-app-in-miro) by clicking **Edit in Manifest**. \
-   In the app manifest editor, configure the app as follows:
+   In the app manifest editor, configure the app as follows, and then click save:
 
-   - [`sdkUri`](https://developers.miro.com/docs/app-manifest#sdkuri): assign `http://localhost:3000` as a value for this property. \
-     It defines the entry point of the app, and it corresponds to the URL of the server that the app runs on.
-   - [`scopes`](https://developers.miro.com/docs/app-manifest#scopes): add the permission scopes that users need to grant the app when they install it. \
-     To enable the app to read from and write to the board, add the following permissions:
-     - `boards:read`
-     - `boards:write`
+```yaml
+# See https://developers.miro.com/docs/app-manifest on how to use this
+appName: Connect Firebase
+sdkVersion: SDK_V2
+sdkUri: http://localhost:3000
+scopes:
+  - boards:read
+  - boards:write
+```
 
 5. Go back to your app home page, and under the `Permissions` section, you will see a blue button that says `Install app and get OAuth token`. Click that button. Then click on `Add` as shown in the video below. <b>In the video we install a different app, but the process is the same regardless of the app.</b>
 

--- a/examples/csv-to-mindmap/README.md
+++ b/examples/csv-to-mindmap/README.md
@@ -61,14 +61,17 @@ Watch the short video (48 seconds) below to gain a quick overview of using the a
    http://localhost:3000
    ```
 3. Open the [app manifest editor](https://developers.miro.com/docs/manually-create-an-app#step-2-configure-your-app-in-miro) by clicking **Edit in Manifest**. \
-   In the app manifest editor, configure the app as follows:
+   In the app manifest editor, configure the app as follows, and then click save:
 
-   - [`sdkUri`](https://developers.miro.com/docs/app-manifest#sdkuri): assign `http://localhost:3000` as a value for this property. \
-     It defines the entry point of the app, and it corresponds to the URL of the server that the app runs on.
-   - [`scopes`](https://developers.miro.com/docs/app-manifest#scopes): add the permission scopes that users need to grant the app when they install it. \
-     To enable the app to read from and write to the board, add the following permissions:
-     - `boards:read`
-     - `boards:write`
+```yaml
+# See https://developers.miro.com/docs/app-manifest on how to use this
+appName: CSV to Mindmap
+sdkVersion: SDK_V2
+sdkUri: http://localhost:3000
+scopes:
+  - boards:read
+  - boards:write
+```
 
 4. Go back to your app home page, and under the `Permissions` section, you will see a blue button that says `Install app and get OAuth token`. Click that button. Then click on `Add` as shown in the video below. <b>In the video we install a different app, but the process is the same regardless of the app.</b>
 

--- a/examples/custom-actions/README.md
+++ b/examples/custom-actions/README.md
@@ -53,14 +53,17 @@ https://github.com/miroapp/app-examples/assets/10800544/4cd2c24b-877a-4ac0-a512-
    http://localhost:3000
    ```
 3. Open the [app manifest editor](https://developers.miro.com/docs/manually-create-an-app#step-2-configure-your-app-in-miro) by clicking **Edit in Manifest**. \
-   In the app manifest editor, configure the app as follows:
+   In the app manifest editor, configure the app as follows and then click save:
 
-   - [`sdkUri`](https://developers.miro.com/docs/app-manifest#sdkuri): assign `http://localhost:3000` as a value for this property. \
-     It defines the entry point of the app, and it corresponds to the URL of the server that the app runs on.
-   - [`scopes`](https://developers.miro.com/docs/app-manifest#scopes): add the permission scopes that users need to grant the app when they install it. \
-     To enable the app to read from and write to the board, add the following permissions:
-     - `boards:read`
-     - `boards:write`
+```yaml
+# See https://developers.miro.com/docs/app-manifest on how to use this
+appName: Custom Actions
+sdkVersion: SDK_V2
+sdkUri: http://localhost:3000
+scopes:
+  - boards:read
+  - boards:write
+```
 
 4. Go back to your app home page, and under the `Permissions` section, you will see a blue button that says `Install app and get OAuth token`. Click that button. Then click on `Add` as shown in the video below. <b>In the video we install a different app, but the process is the same regardless of the app.</b>
 

--- a/examples/digital-asset-manager/README.md
+++ b/examples/digital-asset-manager/README.md
@@ -58,14 +58,17 @@ https://github.com/miroapp/app-examples/assets/10800544/5eb60feb-1378-4691-a9dd-
    http://localhost:3000
    ```
 3. Open the [app manifest editor](https://developers.miro.com/docs/manually-create-an-app#step-2-configure-your-app-in-miro) by clicking **Edit in Manifest**. \
-   In the app manifest editor, configure the app as follows:
+   In the app manifest editor, configure the app as follows and click save:
 
-   - [`sdkUri`](https://developers.miro.com/docs/app-manifest#sdkuri): assign `http://localhost:3000` as a value for this property. \
-     It defines the entry point of the app, and it corresponds to the URL of the server that the app runs on.
-   - [`scopes`](https://developers.miro.com/docs/app-manifest#scopes): add the permission scopes that users need to grant the app when they install it. \
-     To enable the app to read from and write to the board, add the following permissions:
-     - `boards:read`
-     - `boards:write`
+```yaml
+# See https://developers.miro.com/docs/app-manifest on how to use this
+appName: Digital Asset Manager
+sdkVersion: SDK_V2
+sdkUri: http://localhost:3000
+scopes:
+  - boards:read
+  - boards:write
+```
 
 4. Go back to your app home page, and under the `Permissions` section, you will see a blue button that says `Install app and get OAuth token`. Click that button. Then click on `Add` as shown in the video below.
 

--- a/examples/drag-and-drop/README.md
+++ b/examples/drag-and-drop/README.md
@@ -52,14 +52,17 @@ https://github.com/horeaporutiu/app-examples-template/assets/10428517/3e9aa5ea-0
    http://localhost:3000
    ```
 3. Open the [app manifest editor](https://developers.miro.com/docs/manually-create-an-app#step-2-configure-your-app-in-miro) by clicking **Edit in Manifest**. \
-   In the app manifest editor, configure the app as follows:
+   In the app manifest editor, configure the app as follows and then click save:
 
-   - [`sdkUri`](https://developers.miro.com/docs/app-manifest#sdkuri): assign `http://localhost:3000` as a value for this property. \
-     It defines the entry point of the app, and it corresponds to the URL of the server that the app runs on.
-   - [`scopes`](https://developers.miro.com/docs/app-manifest#scopes): add the permission scopes that users need to grant the app when they install it. \
-     To enable the app to read from and write to the board, add the following permissions:
-     - `boards:read`
-     - `boards:write`
+```yaml
+# See https://developers.miro.com/docs/app-manifest on how to use this
+appName: Drag and Drop
+sdkVersion: SDK_V2
+sdkUri: http://localhost:3000
+scopes:
+  - boards:read
+  - boards:write
+```
 
 4. Go back to your app home page, and under the `Permissions` section, you will see a blue button that says `Install app and get OAuth token`. Click that button. Then click on `Add` as shown in the video below.
 

--- a/examples/enterprise-team-management/README.md
+++ b/examples/enterprise-team-management/README.md
@@ -46,19 +46,23 @@ ACCESS_TOKEN="{YOUR_ACCESS_TOKEN}"
 
 3. Run `npm install` to install dependencies.
 4. Open the [app manifest editor](https://developers.miro.com/docs/manually-create-an-app#step-2-configure-your-app-in-miro) by clicking **Edit in Manifest**. \
-   In the app manifest editor, configure the app as follows:
 
-   - [`redirectUris`](https://developers.miro.com/docs/app-manifest#redirectUris): assign `http://localhost:3000` as a value for this property. \
-     It defines the redirect url that the script will use for OAuth2.0.
-   - [`scopes`](https://developers.miro.com/docs/app-manifest#scopes): add the permission scopes that the script will need in order to call each of the included API endpoints. \
-     Add the following permissions:
-     - `boards:read`
-     - `boards:write`
-     - `organizations:read`
-     - `organizations:teams:write`
-     - `organizations:teams:read`
-     - `team:read`
-     - `team:write`
+In the app manifest editor, configure the app as follows and then click save:
+
+```yaml
+# See https://developers.miro.com/docs/app-manifest on how to use this
+appName: Enterprise Team Management
+sdkVersion: SDK_V2
+sdkUri: http://localhost:3000
+scopes:
+  - boards:read
+  - boards:write
+  - organizations:read
+  - organizations:teams:write
+  - organizations:teams:read
+  - team:read
+  - team:write
+```
 
 5. Go back to your app home page, and under the `Permissions` section, you will see a blue button that says `Install app and get OAuth token`. Click that button. Then click on `Add` as shown in the video below. This will generate an access_token.
 

--- a/examples/html-preview/README.md
+++ b/examples/html-preview/README.md
@@ -62,16 +62,19 @@ MIRO_REDIRECT_URL=http://localhost:3000/api/redirect/
    http://localhost:3000
    ```
 4. Open the [app manifest editor](https://developers.miro.com/docs/manually-create-an-app#step-2-configure-your-app-in-miro) by clicking **Edit in Manifest**. \
-   In the app manifest editor, configure the app as follows:
+   In the app manifest editor, configure the app as follows and click save:
 
-   - [`sdkUri`](https://developers.miro.com/docs/app-manifest#sdkuri): assign `http://localhost:3000` as a value for this property. \
-   - [`redirectUris`](https://developers.miro.com/docs/app-manifest?utm_source=app_manifest_editor#redirecturis): assign `http://localhost:3000/api/redirect/` as a value for this property. \
-   - [`redirectUriForSdk`](https://developers.miro.com/docs/app-manifest?utm_source=app_manifest_editor#redirecturiforsdk): assign `http://localhost:3000/api/redirect/` as a value for this property. \
-     It defines the entry point of the app, and it corresponds to the URL of the server that the app runs on.
-   - [`scopes`](https://developers.miro.com/docs/app-manifest#scopes): add the permission scopes that users need to grant the app when they install it. \
-     To enable the app to read from and write to the board, add the following permissions:
-     - `boards:read`
-     - `boards:write`
+```yaml
+# See https://developers.miro.com/docs/app-manifest on how to use this
+appName: HTML Preview
+sdkVersion: SDK_V2
+sdkUri: http://localhost:3000
+redirectUris: http://localhost:3000/api/redirect/
+redirectUriForSdk: http://localhost:3000/api/redirect/
+scopes:
+  - boards:read
+  - boards:write
+```
 
 5. Go back to your app home page, and under the `Permissions` section, you will see a blue button that says `Install app and get OAuth token`. Click that button. Then click on `Add` as shown in the video below.
 

--- a/examples/monetization-with-stripe/README.md
+++ b/examples/monetization-with-stripe/README.md
@@ -79,15 +79,19 @@ Copy that new link and update it in the [Paywall Component file](https://github.
    http://localhost:3000
    ```
 4. Open the [app manifest editor](https://developers.miro.com/docs/manually-create-an-app#step-2-configure-your-app-in-miro) by clicking **Edit in Manifest**. \
-   In the app manifest editor, configure the app as follows:
 
-   - [`sdkUri`](https://developers.miro.com/docs/app-manifest#sdkuri): assign `http://localhost:3000` as a value for this property.
-   - [`redirectUris`](https://developers.miro.com/docs/app-manifest?utm_source=app_manifest_editor#redirecturis): assign `http://localhost:3000/api/redirect/` as a value for this property.
-     It defines the entry point of the app, and it corresponds to the URL of the server that the app runs on.
-   - [`scopes`](https://developers.miro.com/docs/app-manifest#scopes): add the permission scopes that users need to grant the app when they install it.
-     To enable the app to read from and write to the board, add the following permissions:
-     - `boards:read`
-     - `boards:write`
+   In the app manifest editor, configure the app as follows and click save:
+
+```yaml
+# See https://developers.miro.com/docs/app-manifest on how to use this
+appName: Monetization with Stripe
+sdkVersion: SDK_V2
+sdkUri: http://localhost:3000
+redirectUris: http://localhost:3000/api/redirect/
+scopes:
+  - boards:read
+  - boards:write
+```
 
 5. Go to **Redirect URI for OAuth2.0**, click **Options**. for the localhost path. \
    From the drop-down menu select **Use this URI for SDK authorization**.

--- a/examples/node-stickies-csv/README.md
+++ b/examples/node-stickies-csv/README.md
@@ -60,14 +60,19 @@ MIRO_BOARD_ID=<YOUR_MIRO_BOARD_ID>
    http://localhost:8000
    ```
 4. Open the [app manifest editor](https://developers.miro.com/docs/manually-create-an-app#step-2-configure-your-app-in-miro) by clicking **Edit in Manifest**. \
-   In the app manifest editor, configure the app as follows:
 
-   - [`sdkUri`](https://developers.miro.com/docs/app-manifest#sdkuri): assign `http://localhost:8000` as a value for this property.
-   - [`redirectUris`](https://developers.miro.com/docs/app-manifest?utm_source=app_manifest_editor#redirecturis): assign `http://localhost:8000/authorized/` as a value for this property. \
-   - [`scopes`](https://developers.miro.com/docs/app-manifest#scopes): add the permission scopes that users need to grant the app when they install it. \
-     To enable the app to read from and write to the board, add the following permissions:
-     - `boards:read`
-     - `boards:write`
+In the app manifest editor, configure the app as follows and click save:
+
+```yaml
+# See https://developers.miro.com/docs/app-manifest on how to use this
+appName: Node Stickes CSV
+sdkVersion: SDK_V2
+sdkUri: http://localhost:8000
+redirectUris: http://localhost:8000/authorized/
+scopes:
+  - boards:read
+  - boards:write
+```
 
 5. Go back to your app home page, and under the `Permissions` section, you will see a blue button that says `Install app and get OAuth token`. Click that button. Then click on `Add` as shown in the video below. <b>In the video we install a different app, but the process is the same regardless of the app.</b>
 

--- a/examples/python-flask-starter-with-oauth/README.md
+++ b/examples/python-flask-starter-with-oauth/README.md
@@ -52,14 +52,19 @@ https://github.com/miroapp/app-examples/assets/10800544/767dba77-c3dd-40b0-b6d7-
    - Go to **App Credentials**, and copy the app **Client ID** and **Client secret** values.
    - Paste these details to your `.env` file's `clientID` and `clientSecret` variables.
 4. From your App Settings page, open the [app manifest editor](https://developers.miro.com/docs/manually-create-an-app#step-2-configure-your-app-in-miro) by clicking **Edit in Manifest**. \
-    In the app manifest editor, configure the app as follows:
 
-   - [`redirectUris`](https://developers.miro.com/docs/app-manifest#redirecturis): assign `http://127.0.0.1:5000/callback` as a value for this property. \
-     It defines the redirect URL that starts the OAuth 2.0 code grant flow for the REST API.
-   - [`scopes`](https://developers.miro.com/docs/app-manifest#scopes): add the permission scopes that users need to grant the app when they install it. \
-      To enable the app to read from and write to the board, add the following permissions: - `boards:read` - `boards:write`\
-     \
-     Hit **Save**.
+   In the app manifest editor, configure the app as follows and then click save:
+
+```yaml
+# See https://developers.miro.com/docs/app-manifest on how to use this
+appName: Python Flask Starter with OAuth
+sdkVersion: SDK_V2
+sdkUri: http://127.0.0.1:5000
+redirectUris: http://127.0.0.1:5000/callback
+scopes:
+  - boards:read
+  - boards:write
+```
 
 5. Run the app with `python3 app.py`
 6. Open the page at `http://127.0.0.1:5000`

--- a/examples/selfie-with-custom-action/README.md
+++ b/examples/selfie-with-custom-action/README.md
@@ -53,15 +53,18 @@ https://github.com/miroapp/app-examples/assets/7162412/46b1708d-fb08-412e-a7b2-3
    http://localhost:3000
    ```
 3. Open the [app manifest editor](https://developers.miro.com/docs/manually-create-an-app#step-2-configure-your-app-in-miro) by clicking **Edit in Manifest**. \
-   In the app manifest editor, configure the app as follows:
+   In the app manifest editor, configure the app as follows and click save:
 
-   - [`sdkUri`](https://developers.miro.com/docs/app-manifest#sdkuri): assign `http://localhost:3000` as a value for this property. \
-     It defines the entry point of the app, and it corresponds to the URL of the server that the app runs on.
-   - [`scopes`](https://developers.miro.com/docs/app-manifest#scopes): add the permission scopes that users need to grant the app when they install it. \
-     To enable the app to read from and write to the board, add the following permissions:
-     - `boards:read`
-     - `boards:write`
-     - `webcam:record`
+```yaml
+# See https://developers.miro.com/docs/app-manifest on how to use this
+appName: Selfie with Custom Actions
+sdkVersion: SDK_V2
+sdkUri: http://localhost:3000
+scopes:
+  - boards:read
+  - boards:write
+  - webcam:record
+```
 
 4. Go back to your app home page, and under the `Permissions` section, you will see a blue button that says `Install app and get OAuth token`. Click that button. Then click on `Add` as shown in the video below. <b>In the video we install a different app, but the process is the same regardless of the app.</b>
 

--- a/examples/stickynotes-to-shapes/README.md
+++ b/examples/stickynotes-to-shapes/README.md
@@ -52,14 +52,17 @@ This app shows how you can select items on the board, and then click the app ico
    http://localhost:3000
    ```
 3. Open the [app manifest editor](https://developers.miro.com/docs/manually-create-an-app#step-2-configure-your-app-in-miro) by clicking **Edit in Manifest**. \
-   In the app manifest editor, configure the app as follows:
+   In the app manifest editor, configure the app as follows and then click save:
 
-   - [`sdkUri`](https://developers.miro.com/docs/app-manifest#sdkuri): assign `http://localhost:3000` as a value for this property. \
-     It defines the entry point of the app, and it corresponds to the URL of the server that the app runs on.
-   - [`scopes`](https://developers.miro.com/docs/app-manifest#scopes): add the permission scopes that users need to grant the app when they install it. \
-     To enable the app to read from and write to the board, add the following permissions:
-     - `boards:read`
-     - `boards:write`
+```yaml
+# See https://developers.miro.com/docs/app-manifest on how to use this
+appName: Stickynotes to Shapes
+sdkVersion: SDK_V2
+sdkUri: http://localhost:3000
+scopes:
+  - boards:read
+  - boards:write
+```
 
 4. Go back to your app home page, and under the `Permissions` section, you will see a blue button that says `Install app and get OAuth token`. Click that button. Then click on `Add` as shown in the video below. <b>In the video we install a different app, but the process is the same regardless of the app.</b>
 

--- a/examples/template-builder/README.md
+++ b/examples/template-builder/README.md
@@ -47,12 +47,15 @@ https://github.com/miroapp/app-examples/assets/10428517/24aacae3-5183-4142-bdae-
 3. Open the [app manifest editor](https://developers.miro.com/docs/manually-create-an-app#step-2-configure-your-app-in-miro) by clicking **Edit in Manifest**. \
    In the app manifest editor, configure the app as follows:
 
-   - [`sdkUri`](https://developers.miro.com/docs/app-manifest#sdkuri): assign `http://localhost:3000` as a value for this property. \
-     It defines the entry point of the app, and it corresponds to the URL of the server that the app runs on.
-   - [`scopes`](https://developers.miro.com/docs/app-manifest#scopes): add the permission scopes that users need to grant the app when they install it. \
-     To enable the app to read from and write to the board, add the following permissions:
-     - `boards:read`
-     - `boards:write`
+```yaml
+# See https://developers.miro.com/docs/app-manifest on how to use this
+appName: Template Builder
+sdkVersion: SDK_V2
+sdkUri: http://localhost:3000
+scopes:
+  - boards:read
+  - boards:write
+```
 
 4. Go back to your app home page, and under the `Permissions` section, you will see a blue button that says `Install app and get OAuth token`. Click that button. Then click on `Add` as shown in the video below. <b>In the video we install a different app, but the process is the same regardless of the app.</b>
 

--- a/examples/webhooks-manager/README.md
+++ b/examples/webhooks-manager/README.md
@@ -53,14 +53,17 @@ https://github.com/miroapp/app-examples/assets/10800544/eb993044-370d-49de-b9a8-
    http://localhost:3000
    ```
 3. Open the [app manifest editor](https://developers.miro.com/docs/manually-create-an-app#step-2-configure-your-app-in-miro) by clicking **Edit in Manifest**. \
-   In the app manifest editor, configure the app as follows:
+   In the app manifest editor, configure the app as follows and then click save:
 
-   - [`sdkUri`](https://developers.miro.com/docs/app-manifest#sdkuri): assign `http://localhost:3000` as a value for this property. \
-     It defines the entry point of the app, and it corresponds to the URL of the server that the app runs on.
-   - [`scopes`](https://developers.miro.com/docs/app-manifest#scopes): add the permission scopes that users need to grant the app when they install it. \
-     To enable the app to read from and write to the board, add the following permissions:
-     - `boards:read`
-     - `boards:write`
+```yaml
+# See https://developers.miro.com/docs/app-manifest on how to use this
+appName: Webhooks Manager
+sdkVersion: SDK_V2
+sdkUri: http://localhost:3000
+scopes:
+  - boards:read
+  - boards:write
+```
 
 4. Go back to your app home page, and under the `Permissions` section, you will see a blue button that says `Install app and get OAuth token`. Click that button. Then click on `Add` as shown in the video below. <b>In the video we install a different app, but the process is the same regardless of the app.</b>
 

--- a/examples/wordle/README.md
+++ b/examples/wordle/README.md
@@ -49,14 +49,17 @@ https://github.com/miroapp/app-examples/assets/10428517/56fe0932-2608-47ae-9e08-
    http://localhost:3000
    ```
 3. Open the [app manifest editor](https://developers.miro.com/docs/manually-create-an-app#step-2-configure-your-app-in-miro) by clicking **Edit in Manifest**. \
-   In the app manifest editor, configure the app as follows:
+   In the app manifest editor, configure the app as follows and then click save:
 
-   - [`sdkUri`](https://developers.miro.com/docs/app-manifest#sdkuri): assign `http://localhost:3000` as a value for this property. \
-     It defines the entry point of the app, and it corresponds to the URL of the server that the app runs on.
-   - [`scopes`](https://developers.miro.com/docs/app-manifest#scopes): add the permission scopes that users need to grant the app when they install it. \
-     To enable the app to read from and write to the board, add the following permissions:
-     - `boards:read`
-     - `boards:write`
+```yaml
+# See https://developers.miro.com/docs/app-manifest on how to use this
+appName: Wordle
+sdkVersion: SDK_V2
+sdkUri: http://localhost:3000
+scopes:
+  - boards:read
+  - boards:write
+```
 
 4. Go back to your app home page, and under the `Permissions` section, you will see a blue button that says `Install app and get OAuth token`. Click that button. Then click on `Add` as shown in the video below. <b>In the video we install a different app, but the process is the same regardless of the app.</b>
 


### PR DESCRIPTION
Some examples used yaml, others did not. Made them all yaml for easy copy paste